### PR TITLE
Add verbose logging flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,12 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	verbose, _ := rootCmd.PersistentFlags().GetBool("verbose")
+
+	if verbose {
+		log.SetLevel(log.DebugLevel)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -34,14 +40,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fab.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().Bool("verbose", true, "Verbose output logs")
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
Addresses https://github.com/Microsoft/fabrikate/projects/1#card-16394679 - add a verbose flag (either -v or --verbose) to Fabrikate for debug output.