### PR TITLE
Add support for before-install and after-install hooks 

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,21 +10,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Install installs the component at the given path and all of its subcomponents.
 func Install(path string) (err error) {
 	_, err = core.IterateComponentTree(path, "", func(path string, component *core.Component) (err error) {
 		log.Info(emoji.Sprintf(":point_right: starting install for component: %s", component.Name))
-		if err := component.Install(path); err != nil {
-			return err
-		}
+
+		var generator core.Generator
 
 		switch component.Generator {
 		case "helm":
-			err = generators.InstallHelmComponent(component)
+			generator = &generators.HelmGenerator{}
 		}
 
-		if err == nil {
-			log.Info(emoji.Sprintf(":point_left: finished install for component: %s", component.Name))
+		if err := component.Install(path, generator); err != nil {
+			return err
 		}
+
+		log.Info(emoji.Sprintf(":point_left: finished install for component: %s", component.Name))
 
 		return err
 	})

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -17,3 +17,9 @@ func TestInstallYAML(t *testing.T) {
 
 	assert.Nil(t, err)
 }
+
+func TestInstallWithBeforeHook(t *testing.T) {
+	err := Install("../test/fixtures/before-install")
+
+	assert.Nil(t, err)
+}

--- a/core/component.go
+++ b/core/component.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
@@ -15,17 +16,19 @@ import (
 )
 
 type Component struct {
-	Name   string
-	Source string
-	Method string
+	Name      string
+	Config    ComponentConfig
+	Generator string
+	Hooks     map[string][]string
+	Source    string
+	Method    string
+	Path      string
+	Repo      string
 
-	Generator     string
 	Subcomponents []Component
-	Repo          string
-	Path          string
-	PhysicalPath  string
-	LogicalPath   string
-	Config        ComponentConfig
+
+	PhysicalPath string
+	LogicalPath  string
 
 	Manifest string
 }
@@ -112,27 +115,81 @@ func (c *Component) RelativePathTo() string {
 	}
 }
 
-func (c *Component) Install(componentPath string) (err error) {
-	for _, subcomponent := range c.Subcomponents {
-		if subcomponent.Method == "git" {
-			componentsPath := fmt.Sprintf("%s/components", componentPath)
-			if err := exec.Command("mkdir", "-p", componentsPath).Run(); err != nil {
-				return err
-			}
+func (c *Component) ExecuteHook(hook string) (err error) {
+	if c.Hooks[hook] == nil {
+		return nil
+	}
 
-			subcomponentPath := path.Join(componentPath, subcomponent.RelativePathTo())
-			if err = exec.Command("rm", "-rf", subcomponentPath).Run(); err != nil {
-				return err
-			}
+	log.Infof("executing hooks for: %s", hook)
 
-			log.Println(emoji.Sprintf(":helicopter: installing component %s with git from %s", subcomponent.Name, subcomponent.Source))
-			if err = exec.Command("git", "clone", subcomponent.Source, subcomponentPath).Run(); err != nil {
+	for _, command := range c.Hooks[hook] {
+		log.Infof("executing command: %s", command)
+		commandComponents := strings.Fields(command)
+		if len(commandComponents) != 0 {
+			commandExecutable := commandComponents[0]
+			commandArgs := commandComponents[1:len(commandComponents)]
+			cmd := exec.Command(commandExecutable, commandArgs...)
+			cmd.Dir = c.PhysicalPath
+			if err := cmd.Run(); err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					log.Errorf("hook command failed with: %s\n", ee.Stderr)
+				}
+
 				return err
 			}
 		}
 	}
 
 	return nil
+}
+
+func (c *Component) BeforeInstall() (err error) {
+	return c.ExecuteHook("before-install")
+}
+
+func (c *Component) AfterInstall() (err error) {
+	return c.ExecuteHook("after-install")
+}
+
+func (c *Component) InstallComponent(componentPath string) (err error) {
+	if c.Method == "git" {
+		componentsPath := fmt.Sprintf("%s/components", componentPath)
+		if err := exec.Command("mkdir", "-p", componentsPath).Run(); err != nil {
+			return err
+		}
+
+		subcomponentPath := path.Join(componentPath, c.RelativePathTo())
+		if err = exec.Command("rm", "-rf", subcomponentPath).Run(); err != nil {
+			return err
+		}
+
+		log.Println(emoji.Sprintf(":helicopter: installing component %s with git from %s", c.Name, c.Source))
+		if err = exec.Command("git", "clone", c.Source, subcomponentPath).Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Component) Install(componentPath string, generator Generator) (err error) {
+	if err := c.BeforeInstall(); err != nil {
+		return err
+	}
+
+	for _, subcomponent := range c.Subcomponents {
+		if err := subcomponent.InstallComponent(componentPath); err != nil {
+			return err
+		}
+	}
+
+	if generator != nil {
+		if err := generator.Install(c); err != nil {
+			return err
+		}
+	}
+
+	return c.AfterInstall()
 }
 
 type ComponentIteration func(path string, component *Component) (err error)

--- a/core/generator.go
+++ b/core/generator.go
@@ -1,0 +1,6 @@
+package core
+
+type Generator interface {
+	Generate(component *Component) (manifest string, err error)
+	Install(component *Component) (err error)
+}

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -14,6 +14,8 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type HelmGenerator struct{}
+
 func AddNamespaceToManifests(manifests string, namespace string) (namespacedManifests string, err error) {
 	splitManifest := strings.Split(manifests, "\n---")
 
@@ -45,7 +47,7 @@ func AddNamespaceToManifests(manifests string, namespace string) (namespacedMani
 	return namespacedManifests, nil
 }
 
-func MakeHelmRepoPath(component *core.Component) string {
+func (hg *HelmGenerator) MakeHelmRepoPath(component *core.Component) string {
 	if len(component.Repo) == 0 {
 		return component.PhysicalPath
 	} else {
@@ -53,7 +55,7 @@ func MakeHelmRepoPath(component *core.Component) string {
 	}
 }
 
-func GenerateHelmComponent(component *core.Component) (manifest string, err error) {
+func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, err error) {
 	log.Println(emoji.Sprintf(":truck: generating component '%s' with helm with repo %s", component.Name, component.Repo))
 
 	configYaml, err := yaml.Marshal(&component.Config.Config)
@@ -62,7 +64,7 @@ func GenerateHelmComponent(component *core.Component) (manifest string, err erro
 		return "", err
 	}
 
-	helmRepoPath := MakeHelmRepoPath(component)
+	helmRepoPath := hg.MakeHelmRepoPath(component)
 	absHelmRepoPath, err := filepath.Abs(helmRepoPath)
 	if err != nil {
 		return "", err
@@ -106,12 +108,12 @@ func GenerateHelmComponent(component *core.Component) (manifest string, err erro
 	return stringManifests, err
 }
 
-func InstallHelmComponent(component *core.Component) (err error) {
+func (hg *HelmGenerator) Install(component *core.Component) (err error) {
 	if len(component.Repo) == 0 {
 		return nil
 	}
 
-	helmRepoPath := MakeHelmRepoPath(component)
+	helmRepoPath := hg.MakeHelmRepoPath(component)
 	if err := exec.Command("rm", "-rf", helmRepoPath).Run(); err != nil {
 		return err
 	}

--- a/generators/static.go
+++ b/generators/static.go
@@ -10,7 +10,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func GenerateStaticComponent(component *core.Component) (manifest string, err error) {
+type StaticGenerator struct{}
+
+func (sg *StaticGenerator) Generate(component *core.Component) (manifest string, err error) {
 	log.Println(emoji.Sprintf(":truck: generating component '%s' statically from path %s", component.Name, component.Path))
 
 	staticPath := path.Join(component.PhysicalPath, component.Path)
@@ -29,4 +31,8 @@ func GenerateStaticComponent(component *core.Component) (manifest string, err er
 	}
 
 	return manifests, err
+}
+
+func (hg *StaticGenerator) Install(component *core.Component) (err error) {
+	return nil
 }

--- a/test/fixtures/before-install/component.json
+++ b/test/fixtures/before-install/component.json
@@ -1,0 +1,19 @@
+{
+    "name": "istio",
+    "generator": "static",
+    "path": "./manifests",
+    "hooks": {
+        "before-install": [
+            "wget https://github.com/istio/istio/releases/download/1.0.5/istio-1.0.5-linux.tar.gz",
+            "tar xvf istio-1.0.5-linux.tar.gz"
+        ],
+        "after-install": ["rm istio-1.0.5-linux.tar.gz", "rm -rf istio-1.0.5"]
+    },
+    "subcomponents": [
+        {
+            "name": "istio",
+            "generator": "helm",
+            "path": "./istio-1.0.5/install/kubernetes/helm/istio"
+        }
+    ]
+}


### PR DESCRIPTION
Add support for before-install and after-install hooks (see test/fixtures/before-install/component.json for syntax).  

In the process, clean up helm and static generators by defining a core Generator interface and making HelmGenerator and StaticGenerator implementations of this interface, and also clean up and have Component own lifecycle tasks like `install` and `generate` as well as hooks like these.

Addresses https://github.com/Microsoft/fabrikate/issues/17