### PR TITLE
 Move to fork of yaml parser that always parses into map[string]interface{}

### DIFF
--- a/core/component.go
+++ b/core/component.go
@@ -12,7 +12,7 @@ import (
 	"github.com/kyokomi/emoji"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	yaml "github.com/superwhiskers/yaml"
 )
 
 type Component struct {


### PR DESCRIPTION
See https://github.com/go-yaml/yaml/issues/139 for details.