### PR TITLE
Add --no-validation flag to suppress validation of generated resource manifests.

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -17,7 +17,7 @@ func checkComponentLengthsAgainstExpected(t *testing.T, components []core.Compon
 }
 
 func TestGenerateJSON(t *testing.T) {
-	components, err := Generate("../test/fixtures/generate", []string{"prod-east", "prod"})
+	components, err := Generate("../test/fixtures/generate", []string{"prod-east", "prod"}, false)
 
 	assert.Nil(t, err)
 
@@ -35,7 +35,7 @@ func TestGenerateJSON(t *testing.T) {
 }
 
 func TestGenerateYAML(t *testing.T) {
-	components, err := Generate("../test/fixtures/generate-yaml", []string{"prod"})
+	components, err := Generate("../test/fixtures/generate-yaml", []string{"prod"}, false)
 
 	expectedLengths := map[string]int{
 		"prometheus-grafana": 125,
@@ -51,7 +51,7 @@ func TestGenerateYAML(t *testing.T) {
 }
 
 func TestGenerateWithHooks(t *testing.T) {
-	_, err := Generate("../test/fixtures/generate-hooks", []string{"prod"})
+	_, err := Generate("../test/fixtures/generate-hooks", []string{"prod"}, false)
 
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Addresses https://github.com/Microsoft/fabrikate/issues/49