### PR TITLE
Switch to fork on conjungo that does not complain on merging two values

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -39,7 +39,7 @@ func TestGenerateYAML(t *testing.T) {
 
 	expectedLengths := map[string]int{
 		"prometheus-grafana": 125,
-		"grafana":            8581,
+		"grafana":            8575,
 		"prometheus":         21401,
 	}
 

--- a/core/component.go
+++ b/core/component.go
@@ -96,10 +96,6 @@ func (c *Component) MergeConfigFile(environment string) (err error) {
 		}
 	}
 
-	if err = componentConfig.CoerceConfigToStrings(); err != nil {
-		return err
-	}
-
 	return c.Config.Merge(componentConfig)
 }
 

--- a/core/componentConfig.go
+++ b/core/componentConfig.go
@@ -1,83 +1,12 @@
 package core
 
 import (
-	"fmt"
-	"reflect"
-
-	"github.com/InVisionApp/conjungo"
+	"github.com/timfpark/conjungo"
 )
 
 type ComponentConfig struct {
 	Config        map[string]interface{}
 	Subcomponents map[string]ComponentConfig
-}
-
-func coerceSliceValuesToStrings(configSlice []interface{}) (coercedSlice []interface{}, err error) {
-	for idx, element := range configSlice {
-		if element == nil {
-			// nop: leave value as-is (nil)
-		} else if reflect.TypeOf(element).Kind() == reflect.Bool {
-			// nop: leave value as-is
-		} else if reflect.TypeOf(element).Kind() == reflect.Map {
-			configSlice[idx], err = coerceMapValuesToStrings(element.(map[string]interface{}))
-
-			if err != nil {
-				return configSlice, err
-			}
-		} else if reflect.TypeOf(element).Kind() == reflect.Slice {
-			configSlice[idx], err = coerceSliceValuesToStrings(element.([]interface{}))
-
-			if err != nil {
-				return configSlice, err
-			}
-		} else {
-			configSlice[idx] = fmt.Sprintf("%v", configSlice[idx])
-		}
-	}
-
-	return configSlice, nil
-}
-
-func coerceMapValuesToStrings(configMap map[string]interface{}) (coercedMap map[string]interface{}, err error) {
-	for key, value := range configMap {
-		if value == nil {
-			// nop: leave value as-is (nil)
-		} else if reflect.TypeOf(value).Kind() == reflect.Bool {
-			// nop: leave value as-is
-		} else if reflect.TypeOf(value).Kind() == reflect.Map {
-			configMap[key], err = coerceMapValuesToStrings(configMap[key].(map[string]interface{}))
-
-			if err != nil {
-				return configMap, err
-			}
-		} else if reflect.TypeOf(value).Kind() == reflect.Slice {
-			configMap[key], err = coerceSliceValuesToStrings(configMap[key].([]interface{}))
-
-			if err != nil {
-				return configMap, err
-			}
-		} else {
-			configMap[key] = fmt.Sprintf("%v", configMap[key])
-		}
-	}
-
-	return configMap, nil
-}
-
-func (cc *ComponentConfig) CoerceConfigToStrings() (err error) {
-	cc.Config, err = coerceMapValuesToStrings(cc.Config)
-
-	if err != nil {
-		return err
-	}
-
-	for _, subcomponent := range cc.Subcomponents {
-		if err = subcomponent.CoerceConfigToStrings(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (cc *ComponentConfig) Merge(newConfig ComponentConfig) (err error) {

--- a/core/componentConfig_test.go
+++ b/core/componentConfig_test.go
@@ -48,13 +48,7 @@ func TestMergeConfig(t *testing.T) {
 		},
 	}
 
-	err := currentConfig.CoerceConfigToStrings()
-	assert.Nil(t, err)
-
-	err = newConfig.CoerceConfigToStrings()
-	assert.Nil(t, err)
-
-	err = currentConfig.Merge(newConfig)
+	err := currentConfig.Merge(newConfig)
 	assert.Nil(t, err)
 
 	jaegerSubcomponent := currentConfig.Subcomponents["jaeger"]
@@ -66,9 +60,9 @@ func TestMergeConfig(t *testing.T) {
 	elasticsearchValue := provisionConfig["elasticsearch"].(bool)
 	assert.Equal(t, false, elasticsearchValue)
 
-	mixed := provisionConfig["mixed"].(string)
-	assert.Equal(t, "1", mixed)
+	mixed := provisionConfig["mixed"].(int)
+	assert.Equal(t, 1, mixed)
 
 	sliceValues := provisionConfig["slice"].([]interface{})
-	assert.Equal(t, "1", sliceValues[1].(string))
+	assert.Equal(t, 1, sliceValues[1].(int))
 }


### PR DESCRIPTION
Since our  "highest in hierarchy" model means they will not be merged anyway, it does not matter that there is a difference in values between the two sides, so just ignore.

Addresses https://github.com/Microsoft/fabrikate/issues/56