### PR TITLE
Switch the default for fab generation to opting into validation

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -105,19 +105,20 @@ If multiple configurations are specified, each will be applied in left to right 
 For example, 'fab generate prod east' will generate to a directory named prod-east.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		PrintVersion()
-
+		
 		if len(args) < 1 || len(args) > 2 {
 			return errors.New("generate takes at one or more environment arguments, specified in priority order.")
 		}
-
-		noValidation := cmd.Flag("no-validation").Value.String()
-		_, err := Generate("./", args, noValidation == "false")
-
+		
+		validation := cmd.Flag("validate").Value.String()
+		_, err := Generate("./", args, validation == "true")
+		
+	
 		return err
 	},
 }
 
 func init() {
-	generateCmd.PersistentFlags().Bool("no-validation", false, "Do not validate generated resource manifest YAML")
+	generateCmd.PersistentFlags().Bool("validate", false, "Validate generated resource manifest YAML")
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -105,15 +105,14 @@ If multiple configurations are specified, each will be applied in left to right 
 For example, 'fab generate prod east' will generate to a directory named prod-east.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		PrintVersion()
-		
+
 		if len(args) < 1 || len(args) > 2 {
 			return errors.New("generate takes at one or more environment arguments, specified in priority order.")
 		}
-		
+
 		validation := cmd.Flag("validate").Value.String()
 		_, err := Generate("./", args, validation == "true")
-		
-	
+
 		return err
 	},
 }


### PR DESCRIPTION
No major code changes.

The `fab generate ...` command should now validate when using the `--validate` argument, and by default, validation is disabled.

This PR corresponds to https://github.com/Microsoft/fabrikate/issues/63.