### PR TITLE
Asynchronous Component Tree Walk/Iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ components
 releases
 helm_repos
 .DS_Store
+.idea
+fab

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -9,7 +9,15 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	err := os.Chdir("../test/fixtures/add")
+
+	// This test changes the cwd. Must change back so any tests following don't break
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		os.Chdir(cwd)
+	}()
+
+	err = os.Chdir("../test/fixtures/add")
 	assert.Nil(t, err)
 
 	_ = os.Remove("./component.yaml")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -56,7 +56,7 @@ func ValidateGeneratedManifests(generationPath string) (err error) {
 
 func Generate(startPath string, environments []string, validate bool) (components []core.Component, err error) {
 	// Iterate through component tree and generate
-	components, err = core.IterateComponentTree(startPath, environments, func(path string, component *core.Component) (err error) {
+	results := core.WalkComponentTree(startPath, environments, func(path string, component *core.Component) (err error) {
 
 		var generator core.Generator
 		switch component.Generator {
@@ -68,6 +68,8 @@ func Generate(startPath string, environments []string, validate bool) (component
 
 		return component.Generate(generator)
 	})
+
+	components, err = core.SynchronizeWalkResult(results)
 
 	if err != nil {
 		return nil, err

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -19,7 +19,7 @@ func Install(path string) (err error) {
 		return err
 	}
 
-	_, err = core.IterateComponentTree(path, []string{}, func(path string, component *core.Component) (err error) {
+	results := core.WalkComponentTree(path, []string{}, func(path string, component *core.Component) (err error) {
 		log.Info(emoji.Sprintf(":point_right: starting install for component: %s", component.Name))
 
 		var generator core.Generator
@@ -38,9 +38,15 @@ func Install(path string) (err error) {
 		return err
 	})
 
-	if err == nil {
-		log.Info(emoji.Sprintf(":raised_hands: finished install"))
+	components, err := core.SynchronizeWalkResult(results)
+	if err != nil {
+		return err
 	}
+
+	for _, component := range components {
+		log.Info(emoji.Sprintf(":white_check_mark: installed successfully: %s", component.Name))
+	}
+	log.Info(emoji.Sprintf(":raised_hands: finished install"))
 
 	return err
 }

--- a/core/component_test.go
+++ b/core/component_test.go
@@ -58,20 +58,30 @@ func TestLoadConfig(t *testing.T) {
 
 func TestIteratingDefinition(t *testing.T) {
 	callbackCount := 0
-	results, err := IterateComponentTree("../test/fixtures/iterator", []string{""}, func(path string, component *Component) (err error) {
+	results := WalkComponentTree("../test/fixtures/iterator", []string{""}, func(path string, component *Component) (err error) {
 		callbackCount++
 		return nil
 	})
 
+	var err error
+	components := make([]Component, 0)
+	for result := range results {
+		if result.Error != nil {
+			err = result.Error
+		} else if result.Component != nil {
+			components = append(components, *result.Component)
+		}
+	}
+
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(results))
-	assert.Equal(t, callbackCount, len(results))
+	assert.Equal(t, 3, len(components))
+	assert.Equal(t, callbackCount, len(components))
 
-	assert.Equal(t, results[1].PhysicalPath, "../test/fixtures/iterator/infra")
-	assert.Equal(t, results[1].LogicalPath, "infra")
+	assert.Equal(t, components[1].PhysicalPath, "../test/fixtures/iterator/infra")
+	assert.Equal(t, components[1].LogicalPath, "infra")
 
-	assert.Equal(t, results[2].PhysicalPath, "../test/fixtures/iterator/infra/components/efk")
-	assert.Equal(t, results[2].LogicalPath, "infra/efk")
+	assert.Equal(t, components[2].PhysicalPath, "../test/fixtures/iterator/infra/components/efk")
+	assert.Equal(t, components[2].LogicalPath, "infra/efk")
 }
 
 func TestWriteComponent(t *testing.T) {

--- a/test/fixtures/install/component.json
+++ b/test/fixtures/install/component.json
@@ -1,9 +1,9 @@
 {
-    "name": "microservices-workload",
-    "subcomponents": [
-        {
-            "name": "infra",
-            "source": "./infra"
-        }
-    ]
+  "name": "microservices-workload",
+  "subcomponents": [
+    {
+      "name": "infra",
+      "source": "./infra"
+    }
+  ]
 }


### PR DESCRIPTION
- `IterateComponentTree` is now `WalkComponentTree`; is async and returns a `WalkResult` channel
- Original Breadth First algorithm refined a bit
- Updated `Install` and `Generate` commands to facilitate channels
- Updated tests for `Install` and `Generate` to reflect refactor
- `WalkComponentTree` is ~2.5x-3x faster than `IterateComponentTree` when installing https://github.com/Microsoft/fabrikate-production-cluster-demo
- Performance of `WalkComponentTree` is limited by branching factor of HLD; flatter the better (parent node must be installed/generated before children begin).
- Fixed breaking test in `TestAdd`