### PR TITLE
Fixed race condition in concurrent WalkIterationTree

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -24,7 +24,7 @@ func TestAdd(t *testing.T) {
 
 	componentComponent := core.Component{
 		Name:      "cloud-native",
-		Source:    "https://github.com/timfpark/fabriakte-cloud-native",
+		Source:    "https://github.com/timfpark/fabrikate-cloud-native",
 		Method:    "git",
 		Generator: "component",
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -13,6 +13,15 @@ import (
 
 // Install installs the component at the given path and all of its subcomponents.
 func Install(path string) (err error) {
+	// Make sure host system contains all utils needed by Fabrikate
+	requiredSystemTools := []string{"git", "helm", "sh", "curl"}
+	for _, tool := range requiredSystemTools {
+		path, err := exec.LookPath(tool)
+		if err != nil {
+			return err
+		}
+		log.Info(emoji.Sprintf(":mag: using %s: %s", tool, path))
+	}
 
 	log.Info(emoji.Sprintf(":point_right: Initializing Helm"))
 	if err = exec.Command("helm", "init", "--client-only").Run(); err != nil {


### PR DESCRIPTION
- Fixed race condition in `WalkComponentTree` which would cause premature closing of the returned channel
- Simplified concurrency algorithm for `WalkComponentTree`
- `Install()` now does a system check to see if the required utils are in $PATH
- Fixed typo in `TestAdd`
- Changed hook executor from `bash` to `sh`

closes #148 