### PR TITLE
Fix version number for v0.10.1 release

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ var versionCmd = &cobra.Command{
 
 // PrintVersion prints the current version of Fabrikate being used.
 func PrintVersion() {
-	log.Println("fab version 0.10.0")
+	log.Println("fab version 0.10.1")
 }
 
 func init() {


### PR DESCRIPTION
- Updated version number to 0.10.1 to fix v0.10.0 displaying v0.9.0