### PR TITLE
Added `-f` flag for Set

### DIFF
--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -1,64 +1,113 @@
 package cmd
 
 import (
+	"io/ioutil"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/timfpark/yaml"
 )
 
 func TestSetValue(t *testing.T) {
-	err := os.Chdir("../test/fixtures/set")
+	// This test changes the cwd. Must change back so any tests following don't break
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+
+	err = os.Chdir("../test/fixtures/set")
 	assert.Nil(t, err)
 	noNewConfigKeys := false
 
 	// malformed value assignment, should return error
-	err = Set("test", "", []string{"zoo"}, noNewConfigKeys)
+	err = Set("test", "", []string{"zoo"}, noNewConfigKeys, "")
 	assert.NotNil(t, err)
 
 	// malformed value assignment, should return error
-	err = Set("test", "", []string{"zoo=zaa=wrong"}, noNewConfigKeys)
+	err = Set("test", "", []string{"zoo=zaa=wrong"}, noNewConfigKeys, "")
 	assert.NotNil(t, err)
 
 	// apply 'faa' as value for 'foo' in component 'test' config
-	err = Set("test", "", []string{"foo=faa"}, noNewConfigKeys)
+	err = Set("test", "", []string{"foo=faa"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// apply 'zaa' as value for 'zoo' in subcomponent 'myapp' 'test' config
-	err = Set("test", "myapp", []string{"zoo=zaa"}, noNewConfigKeys)
+	err = Set("test", "myapp", []string{"zoo=zaa"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// create new environment
 	_ = os.Remove("./config/new.yaml")
-	err = Set("new", "myapp", []string{"zoo.zii=zaa"}, noNewConfigKeys)
+	err = Set("new", "myapp", []string{"zoo.zii=zaa"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// update deep config on existing environment
-	err = Set("new", "myapp", []string{"zoo.zii=zbb"}, noNewConfigKeys)
+	err = Set("new", "myapp", []string{"zoo.zii=zbb"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// deep subcomponent config set
-	err = Set("new", "myapp.mysubapp", []string{"foo.bar=zoo"}, noNewConfigKeys)
+	err = Set("new", "myapp.mysubapp", []string{"foo.bar=zoo"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// deep subcomponent config set with string literal in double quotes. ex: \"k8.beta.io/load-balancer-group\"
-	err = Set("new", "myservice.mysubservice", []string{"foo.bar.\"k8.beta.io/load-balancer-group\"=foo-bar-group"}, noNewConfigKeys)
+	err = Set("new", "myservice.mysubservice", []string{"foo.bar.\"k8.beta.io/load-balancer-group\"=foo-bar-group"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
-	err = Set("new", "myservice.mysubservice", []string{"foo.bar.line=solid"}, noNewConfigKeys)
+	err = Set("new", "myservice.mysubservice", []string{"foo.bar.line=solid"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
 	// set existing value with new noNewConfigKeys switch on
 	noNewConfigKeys = true
-	err = Set("new", "myservice.mysubservice", []string{"foo.bar.\"k8.beta.io/load-balancer-group\"=foo-bar-updated"}, noNewConfigKeys)
+	err = Set("new", "myservice.mysubservice", []string{"foo.bar.\"k8.beta.io/load-balancer-group\"=foo-bar-updated"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
-	err = Set("test", "", []string{"foo=faa"}, noNewConfigKeys)
+	err = Set("test", "", []string{"foo=faa"}, noNewConfigKeys, "")
 	assert.Nil(t, err)
 
-	err = Set("test", "", []string{"newfoo=faa"}, noNewConfigKeys)
+	err = Set("test", "", []string{"newfoo=faa"}, noNewConfigKeys, "")
 	assert.NotNil(t, err)
 
-	err = os.Chdir("../../../cmd")
+	////////////////////////////////////////////////////////////////////////////////
+	// Start Set from yaml file
+	////////////////////////////////////////////////////////////////////////////////
+	// Read target file to inject into myapp.subcomponent
+	yamlFile := "inject.yaml"
+	err = Set("fromfile", "myapp.mysubcomponent", []string{}, false, yamlFile)
 	assert.Nil(t, err)
+	bytes, err := ioutil.ReadFile(yamlFile)
+	assert.Nil(t, err)
+
+	// Parse yaml
+	fromFile := map[string]interface{}{}
+	*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
+	err = yaml.Unmarshal(bytes, &fromFile)
+	assert.Nil(t, err)
+
+	// Read into config file
+	configBytes, err := ioutil.ReadFile("config/fromfile.yaml")
+	assert.Nil(t, err)
+	inConfig := map[string]interface{}{}
+	err = yaml.Unmarshal(configBytes, &inConfig)
+	assert.Nil(t, err)
+
+	// Config should match where myapp.mysubcomponent config == values from inject.yaml
+	assert.EqualValues(t, map[string]interface{}{
+		"subcomponents": map[string]interface{}{
+			"myapp": map[string]interface{}{
+				"subcomponents": map[string]interface{}{
+					"mysubcomponent": map[string]interface{}{
+						"config": fromFile,
+					},
+				},
+			},
+		},
+	}, inConfig)
+
+	err = os.Remove("config/fromfile.yaml")
+	assert.Nil(t, err)
+	////////////////////////////////////////////////////////////////////////////////
+	// End Set from yaml file
+	////////////////////////////////////////////////////////////////////////////////
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,7 @@ Sets a config value for a component for a particular config environment in the F
 ### Usage
 
 ```sh
-$ fab set --environment <name> [--subcomponent <subcomponent name>] keyPath1=value1 keyPath2=value2 ... keyPathN=valueN
+$ fab set --environment <name> [--subcomponent <subcomponent name>] [--file <input yaml file>] keyPath1=value1 keyPath2=value2 ... keyPathN=valueN
 ```
 
 ### Examples
@@ -105,6 +105,35 @@ Sets the subkey "replicas" in the key 'data' equal to 5 in the 'common' config (
 
 ```sh
 $ fab set --subcomponent "myapp.mysubcomponent" data.replicas=5 --no-new-config-keys
+```
+
+#### `Set` from a file
+
+Note:
+
+- `.` in keys is not supported
+- List values are not supported; they will be converted to raw strings (`[1, 2, 3]` will convert to `"[1 2 3]"`)
+
+my-config.yaml:
+
+```yaml
+this:
+  is:
+    my:
+      config: file
+      foo: bar
+it: has many keys
+```
+
+```sh
+$ fab set --subcomponent "myapp.mysubcomponent" --file my-config-file.yaml
+```
+
+will set the the config for the subcomponent "mysubcomponent" of the "myapp" component to the contents of my-config.yaml.
+This is the equivalent of executing:
+
+```sh
+$ fab set --subcomponent "myapp.mysubcomponent" this.is.my.config=file this.is.my.foo=bar it="has many keys"
 ```
 
 ## version

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/timfpark/conjungo v1.0.1 h1:W4v6Bvvz8fLGoZm2vqXUlRs14xwt9UH3H/zOOAQ5FpQ=
 github.com/timfpark/conjungo v1.0.1/go.mod h1:86oCya4EhpIkCOkNEkmYjCSlI55Ga7SIFlP3D8uHWyg=
-github.com/timfpark/yaml v0.0.0-20190612221433-aec9177fd591 h1:0byKuYqWEss8HPzeTTkOD/XqKWbg45/XrHllh/nAijk=
-github.com/timfpark/yaml v0.0.0-20190612221433-aec9177fd591/go.mod h1:xP+8WOZuY7X55ZX0giNcmB4g0VeHE+DQEVhlzBczF40=
 github.com/timfpark/yaml v0.0.0-20190612232118-2e9e29c9df01 h1:j6cfQEP5CoVnEWdKXq3zS8UjI34t4sMUZn9rgXpBkzE=
 github.com/timfpark/yaml v0.0.0-20190612232118-2e9e29c9df01/go.mod h1:qN0JrENOke+OBA89CZ7X3EKZrqMSU7n+lqmjgi6CWOU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -160,6 +158,7 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/test/fixtures/set/inject.yaml
+++ b/test/fixtures/set/inject.yaml
@@ -1,0 +1,5 @@
+this:
+  is:
+    a:
+      nested: map
+here: is another map

--- a/util/map.go
+++ b/util/map.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"strings"
+)
+
+// CopyMap takes in a map and returns a deep copy of it; not modifying the original at all
+func CopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		vm, ok := v.(map[string]interface{})
+		if ok {
+			cp[k] = CopyMap(vm)
+		} else {
+			cp[k] = v
+		}
+	}
+
+	return cp
+}
+
+// MergeMap takes in two maps and does an immutable merge of the two; applying the new onto the original.
+// This is done immutably; Neither input maps are modified and a deep copy of the original is created, modified, and returned.
+func MergeMap(originalMap map[string]interface{}, newValues map[string]interface{}) map[string]interface{} {
+	// Deep copy the original input map
+	copy := CopyMap(originalMap)
+
+	for k, v := range newValues {
+		// If the original and new values are maps, recursively set the original to a setMap of both values
+		originalNestedMap, originalValueIsMap := copy[k].(map[string]interface{})
+		newNestedMap, newValueIsMap := v.(map[string]interface{})
+
+		if originalValueIsMap && newValueIsMap {
+			copy[k] = MergeMap(originalNestedMap, newNestedMap)
+		} else {
+			copy[k] = v
+		}
+	}
+
+	return copy
+}
+
+// FlattenMap will flatten a map of maps to a flat map with keys being seperated by `keySeperator`
+// This is an immutable function, the original map is not modified and a new map is returned
+func FlattenMap(nestedMap map[string]interface{}, keySeperator string, parentKeys []string) map[string]interface{} {
+	flattened := make(map[string]interface{})
+
+	for k, v := range nestedMap {
+		nestedMap, valueIsMap := v.(map[string]interface{})
+		if valueIsMap {
+			flattenedNestedMap := FlattenMap(nestedMap, keySeperator, append(parentKeys, k))
+			for nk, nv := range flattenedNestedMap {
+				flattened[nk] = nv
+			}
+		} else {
+			flattenedKey := strings.Join(append(parentKeys, k), keySeperator)
+			flattened[flattenedKey] = v
+		}
+	}
+
+	return flattened
+}

--- a/util/map_test.go
+++ b/util/map_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlattenMap(t *testing.T) {
+	nestedMap := map[string]interface{}{
+		"foo": "bar",
+		"im": map[string]interface{}{
+			"a": map[string]interface{}{
+				"really": map[string]interface{}{
+					"nested": "map",
+				},
+				"list": []int{1, 2, 3},
+			}},
+	}
+
+	flattenedWithDots := FlattenMap(nestedMap, ".", []string{})
+	assert.EqualValues(t, map[string]interface{}{
+		"foo":                "bar",
+		"im.a.really.nested": "map",
+		"im.a.list":          []int{1, 2, 3},
+	}, flattenedWithDots)
+
+	flattenedWithDashes := FlattenMap(nestedMap, "-", []string{})
+	assert.EqualValues(t, map[string]interface{}{
+		"foo":                "bar",
+		"im-a-really-nested": "map",
+		"im-a-list":          []int{1, 2, 3},
+	}, flattenedWithDashes)
+}


### PR DESCRIPTION
- Can now point to a YAML file which all values there in will be `Set()

Note: `.` cannot appear in yaml key names and list values are not currently supported