### PR TITLE
Use Go functions instead of shell `mkdir` and `rm`

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,8 +21,7 @@ func writeGeneratedManifests(generationPath string, components []core.Component)
 
 	for _, component := range components {
 		componentGenerationPath := path.Join(generationPath, component.LogicalPath)
-		err := os.MkdirAll(componentGenerationPath, 0755)
-		if err != nil {
+		if err = os.MkdirAll(componentGenerationPath, 0777); err != nil {
 			return err
 		}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,49 +1,67 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
+	"github.com/microsoft/fabrikate/util"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInstallJSON(t *testing.T) {
-	err := Install("../test/fixtures/install")
-
-	if ee, ok := err.(*exec.ExitError); ok {
-		fmt.Printf("TestInstallJSON failed with error %s\n", ee.Stderr)
-	}
-
-	assert.Nil(t, err)
-}
-
-func TestInstallYAML(t *testing.T) {
-	err := Install("../test/fixtures/install-yaml")
-
-	if ee, ok := err.(*exec.ExitError); ok {
-		fmt.Printf("TestInstallYAML failed with error %s\n", ee.Stderr)
-	}
-
-	assert.Nil(t, err)
-}
-
-func TestInstallWithHooks(t *testing.T) {
-	err := Install("../test/fixtures/install-hooks")
-
-	assert.Nil(t, err)
-}
-
-func TestInstallPrivateComponent(t *testing.T) {
+	componentDir := "../test/fixtures/install"
 	cwd, err := os.Getwd()
 	assert.Nil(t, err)
 	defer func() {
-		_ = os.Chdir(cwd)
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
 	}()
 
 	// Change cwd to component directory
-	assert.Nil(t, os.Chdir("../test/fixtures/install-private"))
+	assert.Nil(t, os.Chdir(componentDir))
+	assert.Nil(t, Install("./"))
+}
+
+func TestInstallYAML(t *testing.T) {
+	componentDir := "../test/fixtures/install-yaml"
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
+	}()
+
+	// Change cwd to component directory
+	assert.Nil(t, os.Chdir(componentDir))
+	assert.Nil(t, Install("./"))
+}
+
+func TestInstallWithHooks(t *testing.T) {
+	componentDir := "../test/fixtures/install-hooks"
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
+	}()
+
+	// Change cwd to component directory
+	assert.Nil(t, os.Chdir(componentDir))
+
+	assert.Nil(t, Install("./"))
+}
+
+func TestInstallPrivateComponent(t *testing.T) {
+	componentDir := "../test/fixtures/install-private"
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
+	}()
+
+	// Change cwd to component directory
+	assert.Nil(t, os.Chdir(componentDir))
 
 	// Should fail with no environment var set to personal_access_token
 	assert.NotNil(t, Install("./"))

--- a/core/component.go
+++ b/core/component.go
@@ -190,13 +190,13 @@ func (c *Component) AfterInstall() (err error) {
 // InstallComponent installs the component (if needed) utilizing its Method.
 func (c *Component) InstallComponent(componentPath string, accessTokens map[string]string) (err error) {
 	if c.Method == "git" {
-		componentsPath := fmt.Sprintf("%s/components", componentPath)
-		if err := exec.Command("mkdir", "-p", componentsPath).Run(); err != nil {
+		componentsPath := path.Join(componentPath, "components")
+		if err := os.MkdirAll(componentsPath, 0777); err != nil {
 			return err
 		}
 
 		subcomponentPath := path.Join(componentPath, c.RelativePathTo())
-		if err = exec.Command("rm", "-rf", subcomponentPath).Run(); err != nil {
+		if err = os.RemoveAll(subcomponentPath); err != nil {
 			return err
 		}
 

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -3,6 +3,7 @@ package generators
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -102,7 +103,7 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			log.Errorf("helm template failed with: %s\n", ee.Stderr)
-			_ = exec.Command("rm", absOverriddenPath).Run()
+			_ = os.RemoveAll(absOverriddenPath)
 			return "", err
 		}
 	}
@@ -117,7 +118,7 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 		stringManifests, err = addNamespaceToManifests(stringManifests, component.Config.Namespace)
 	}
 
-	_ = exec.Command("rm", absOverriddenPath).Run()
+	_ = os.RemoveAll(absOverriddenPath)
 
 	return stringManifests, err
 }
@@ -130,11 +131,11 @@ func (hg *HelmGenerator) Install(component *core.Component, accessTokens map[str
 	}
 
 	helmRepoPath := hg.makeHelmRepoPath(component)
-	if err := exec.Command("rm", "-rf", helmRepoPath).Run(); err != nil {
+	if err := os.RemoveAll(helmRepoPath); err != nil {
 		return err
 	}
 
-	if err := exec.Command("mkdir", "-p", helmRepoPath).Run(); err != nil {
+	if err := os.MkdirAll(helmRepoPath, 0777); err != nil {
 		return err
 	}
 

--- a/util/file.go
+++ b/util/file.go
@@ -1,0 +1,40 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// ListComponentInstallDirectories returns all subdirectories in `directory` which have have the name
+// "components" or "helm_repos"; this is mainly used as a helper function for cleaning up test `Install`s
+func ListComponentInstallDirectories(directory string) (componentDirs []string, err error) {
+	err = filepath.Walk(directory, func(path string, file os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if file.IsDir() {
+			if match, err := regexp.MatchString("/(components|helm_repos)$", path); match && err == nil {
+				componentDirs = append(componentDirs, path)
+			}
+		}
+		return nil
+	})
+
+	return componentDirs, err
+}
+
+// UninstallComponents uninstalls any components in any subdirectory under `path`.
+// Equivalent to `rm -rf **/components **/helm_repos`
+func UninstallComponents(path string) (err error) {
+	dirsToClean, err := ListComponentInstallDirectories(path)
+	if err != nil {
+		return err
+	}
+	for _, dir := range dirsToClean {
+		if err = os.RemoveAll(dir); err != nil {
+			return err
+		}
+	}
+	return err
+}


### PR DESCRIPTION
- Now using Go's `MkdirAll` and `RemoveAll` instead of exec'ing shell commands.
- `Install()` tests now do a cleanup step to remove the `components` and `helm_repos` folders they create.