### PR TITLE
Fix race condition for YAML unmashalling

### DIFF
--- a/cmd/set.go
+++ b/cmd/set.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"reflect"
 	"strings"
 
 	"github.com/microsoft/fabrikate/core"
@@ -91,7 +90,6 @@ func Set(environment string, subcomponent string, pathValuePairStrings []string,
 			return err
 		}
 		yamlContent := map[string]interface{}{}
-		*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
 		err = yaml.Unmarshal(bytes, &yamlContent)
 		if err != nil {
 			return err

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,7 +80,6 @@ func TestSetValue(t *testing.T) {
 
 	// Parse yaml
 	fromFile := map[string]interface{}{}
-	*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
 	err = yaml.Unmarshal(bytes, &fromFile)
 	assert.Nil(t, err)
 

--- a/core/component.go
+++ b/core/component.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -85,9 +84,7 @@ func (c *Component) applyDefaultsAndMigrations() {
 }
 
 func (c *Component) LoadComponent() (loadedComponent Component, err error) {
-	*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
 	err = c.UnmarshalComponent("yaml", yaml.Unmarshal, &loadedComponent)
-
 	if err != nil {
 		err = c.UnmarshalComponent("json", json.Unmarshal, &loadedComponent)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"reflect"
+
 	"github.com/microsoft/fabrikate/cmd"
 	log "github.com/sirupsen/logrus"
+	"github.com/timfpark/yaml"
 )
 
 func main() {
+	// modify the DefaultMapType of yaml to map[string]interface{} instead of map[interface]interface{}
+	*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
+
 	formatter := new(log.TextFormatter)
 	formatter.TimestampFormat = "02-01-2006 15:04:05"
 	formatter.FullTimestamp = true


### PR DESCRIPTION
- Fixes a race condition for yaml unmarshalling by moving the modification of go-yaml DefaultMapType to very start of program; no longer changing it every time an unmarshal occurs.