### PR TITLE
Working helm fetch/template

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   GOBIN: "$(GOPATH)/bin" # Go binaries path
-  GOROOT: "/usr/local/go1.11" # Go installation path
+  GOROOT: "/usr/local/go1.12" # Go installation path
   GOPATH: "$(system.defaultWorkingDirectory)/gopath" # Go workspace path
   modulePath: "$(GOPATH)/src/github.com/$(build.repository.name)" # Path to the module's code
   GO111MODULE: "on"

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,12 +40,10 @@ func writeGeneratedManifests(generationPath string, components []core.Component)
 }
 
 func validateGeneratedManifests(generationPath string) (err error) {
-	log.Println(emoji.Sprintf(":microscope: Validating generated manifests in path %s", generationPath))
-	output, err := exec.Command("kubectl", "apply", "--validate=true", "--dry-run", "--recursive", "-f", generationPath).Output()
-
-	if err != nil {
+	log.Info(emoji.Sprintf(":microscope: Validating generated manifests in path %s", generationPath))
+	if output, err := exec.Command("kubectl", "apply", "--validate=true", "--dry-run", "--recursive", "-f", generationPath).Output(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			log.Errorf("Validating generated manifests failed with: %s: output: %s\n", ee.Stderr, output)
+			log.Errorf("Validating generated manifests failed with: %s: output: %s", ee.Stderr, output)
 			return err
 		}
 	}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -25,7 +25,8 @@ func Install(path string) (err error) {
 	}
 
 	log.Info(emoji.Sprintf(":point_right: Initializing Helm"))
-	if err = exec.Command("helm", "init", "--client-only").Run(); err != nil {
+	if output, err := exec.Command("helm", "init", "--client-only").CombinedOutput(); err != nil {
+		log.Error(emoji.Sprintf(":no_entry_sign: %s: %s", err, output))
 		return err
 	}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -74,3 +74,17 @@ func TestInstallPrivateComponent(t *testing.T) {
 		assert.NotNil(t, Install("./"))
 	}
 }
+
+func TestInstallHelmMethod(t *testing.T) {
+	componentDir := "../test/fixtures/install-helm"
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
+	}()
+
+	// Change cwd to component directory
+	assert.Nil(t, os.Chdir(componentDir))
+	assert.Nil(t, Install("./"))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,7 +41,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().Bool("verbose", false, "Use verbose output logs")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Use verbose output logs")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -52,7 +51,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := homedir.Dir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			log.Errorf("Getting home directory failed with: %s\n", err)
 			os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ var versionCmd = &cobra.Command{
 
 // PrintVersion prints the current version of Fabrikate being used.
 func PrintVersion() {
-	log.Println("fab version 0.14.2")
+	log.Info("fab version 0.14.2")
 }
 
 func init() {

--- a/docs/component.md
+++ b/docs/component.md
@@ -5,21 +5,43 @@ specification of a component with the following schema:
 
 - `name`: A free form text name for this component. This name is used to refer to the component in [config specifications](./config.md).
 
-- `type`: Method used to generate the resource manifests for this particular component. Currently, `static` (file based), `helm` (helm based), and `component` (default) are supported values.
+- `type`: Method used to install and generate the resource needed for this particular component. Currently, `static` (file based), `helm` (helm based), and `component` (default) are supported values.
 
-- `source`: The source for this component. This can be a URL for a Git repository (the url you would call `git clone` on) in the case of `method: git` components or a local path to specify a local filesystem component in the case of `method: local`.
+  - if `type: component`: the component itself does not contain any manifests to generate, but is a container for other components.
+  - if `type: helm`: `source` is the helm repository URL and `path` is the name of the target chart; `helm template` will be called on the component during `fab gen`.
+  - if `type: static`: the component holds raw kubernetes manifest files in `path`.
 
-- `method`: The method by which this component is sourced. Currently, only `git` and `local` are supported values.
+- `method`: The method by which this component is sourced. Currently, only `git`, `helm`, and `local` are supported values.
+
+  - if `method: git`: Tells fabrikate to `git clone <source>`.
+  - if `method: helm`: Tells fabrikate to `helm fetch <path>` from the `source` helm repo.
+  - if `method: local`: Tells fabrikate to use the host filesystem as a means to find the component.
+
+- `source`: The source for this component.
+
+  - if `method: git`: A URL for a Git repository (the url you would call `git clone` on).
+  - if `method: helm`: A URL to a helm repository (the url you would call `helm repo add` on).
+  - if `method: local`: A local path to specify a local filesystem component.
 
 - `path`: For some components, like ones generated with `helm`, the desired target of the component might not be located at the root of the repo. Path enables you to specify the relative `path` to this target from the root of the `source`.
 
+  - if `method: git`: the subdirectory of the component in the git repo specified in `source`.
+  - if `method: helm`: the name of the chart to install the repo specified in `source`.
+  - if `method: local`: the subdirectory on host filesystem where the component is located.
+
 - `version`: For git `method` components, this specifies a specific commit SHA hash that the component should be locked to, enabling you to lock the component to a consistent version.
+
+  - if `method: git`: a specific commit to checkout from the repository.
+  - if `method: helm`: noop
+  - if `method: local`: noop
 
 - `branch`: For git `method` components, this specifies the branch that should be checked out after the git `source` is cloned.
 
-- `hooks`: Hooks enable you to execute one or more shell commands before or after the following component lifecycle events: `before-install`, `before-generate`, `after-install`, `after-generate`.
+  - if `method: git`: a specific branch to checkout from the repository.
+  - if `method: helm`: noop
+  - if `method: local`: noop
 
-- `repositories`: A field of key/value pairs consisting of a set of helm repositories that should be added.
+- `hooks`: Hooks enable you to execute one or more shell commands before or after the following component lifecycle events: `before-install`, `before-generate`, `after-install`, `after-generate`.
 
 - `subcomponents`: Zero or more subcomponents that define how to build the resource manifests that make up this component. These subcomponents are components themselves and have exactly the same schema as above.
 

--- a/generators/static.go
+++ b/generators/static.go
@@ -15,7 +15,7 @@ type StaticGenerator struct{}
 
 // Generate iterates a static directory of resource manifests and creates a multi-part manifest.
 func (sg *StaticGenerator) Generate(component *core.Component) (manifest string, err error) {
-	log.Println(emoji.Sprintf(":truck: Generating component '%s' statically from path %s", component.Name, component.Path))
+	log.Info(emoji.Sprintf(":truck: Generating component '%s' statically from path %s", component.Name, component.Path))
 
 	staticPath := path.Join(component.PhysicalPath, component.Path)
 	staticFiles, err := ioutil.ReadDir(staticPath)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/google/uuid v1.1.1
 	github.com/kyokomi/emoji v2.1.0+incompatible
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/otiai10/copy v1.0.1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,5 @@
-# Due to some tests fetching helm repos with nested Go tests in them, we 
+#!/usr/bin/env bash
+# Due to some tests fetching helm repos with nested Go tests in them, we
 # need to specifiy to only test `core` and `cmd` to exclude `test` (which only 
 # contains fixtures)
 go get -v -t ./core/... ./cmd/...

--- a/test/fixtures/install-helm/component.yaml
+++ b/test/fixtures/install-helm/component.yaml
@@ -1,0 +1,22 @@
+name: prometheus
+type: helm
+method: helm
+source: https://kubernetes-charts.storage.googleapis.com
+path: prometheus
+subcomponents:
+  - name: grafana
+    type: helm
+    method: helm
+    source: https://kubernetes-charts.storage.googleapis.com
+    path: grafana
+    subcomponents:
+      - name: strimzi-kafka-operator
+        type: helm
+        method: helm
+        source: https://strimzi.io/charts/
+        path: strimzi-kafka-operator
+      - name: strimzi-kafka-operator2
+        type: helm
+        method: helm
+        source: https://strimzi.io/charts/
+        path: strimzi-kafka-operator


### PR DESCRIPTION
- Added `method: helm` to Component spec. With `method: helm`, you can now specify a target helm repository in `source` and the chart name in `path`.
- Added better logging of error messages when shelling out to host systems (eg. git and helm)
- General cleanups