### PR TITLE
Fix: Warning messages from helm template break NS injection

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -75,7 +75,8 @@ component with the following schema:
 
 ### Prometheus Grafana
 
-This [component specification](https://github.com/timfpark/fabrikate-prometheus-grafana)
+This
+[component specification](https://github.com/timfpark/fabrikate-prometheus-grafana)
 generates static manifests for the `grafana` and `prometheus` namespaces and
 then remotely sources two helm charts for prometheus and grafana respectively.
 
@@ -115,9 +116,8 @@ generator: helm
 path: "./tmp/istio-1.1.2/install/kubernetes/helm/istio"
 hooks:
   before-install:
-    - curl -Lv
-      https://github.com/istio/istio/releases/download/1.1.2/istio-1.1.2-linux.tar.gz
-      -o istio.tar.gz
+    - |
+      curl -Lv https://github.com/istio/istio/releases/download/1.1.2/istio-1.1.2-linux.tar.gz -o istio.tar.gz
     - mkdir -p tmp
     - tar xvf istio.tar.gz -C tmp
   after-install:

--- a/generators/helm_test.go
+++ b/generators/helm_test.go
@@ -1,0 +1,33 @@
+package generators
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanK8sManifest(t *testing.T) {
+	manifest := `
+---
+this should be removed
+---
+this: is a valid map and should stay
+another:
+  entry: in the map
+---
+this should be removed as well
+---
+# This should be removed
+---
+---
+this is another: valid map
+should: not be removed
+---
+# Another to be removed
+`
+	cleaned, err := cleanK8sManifest(manifest)
+	assert.Nil(t, err)
+	entries := strings.Split(cleaned, "\n---")
+	assert.Equal(t, 2, len(entries))
+}


### PR DESCRIPTION
- Non map type entries in the output of `helm template` are now munged from final generated output; a warning is outputted of what the breaking entry was

@sayar

fixes #232 