### PR TITLE
Auto add dependencies in requirements.yaml

### DIFF
--- a/docs/component.md
+++ b/docs/component.md
@@ -7,24 +7,25 @@ component with the following schema:
 - `name`: A free form text name for this component. This name is used to refer
   to the component in [config specifications](./config.md).
 
-- `type`: Method used to install and generate the resource needed for this
-  particular component. Currently, `static` (file based), `helm` (helm based),
-  and `component` (default) are supported values.
+- `type`: Method used generate the manifests for this particular component.
+  Currently, `static` (static manifest based), `helm` (helm based), and
+  `component` (default) are supported values.
 
   - if `type: component`: the component itself does not contain any manifests to
     generate, but is a container for other components.
-  - if `type: helm`: `source` is the helm repository URL and `path` is the name
-    of the target chart; `helm template` will be called on the component during
-    `fab gen`.
+  - if `type: helm`: the component will use `helm template` to materialize the
+    component using the specified config under `config` as the `values.yaml`
+    file.
   - if `type: static`: the component holds raw kubernetes manifest files in
-    `path`.
+    `path`, these manifests will be copied to the generated output.
 
 - `method`: The method by which this component is sourced. Currently, only
   `git`, `helm`, and `local` are supported values.
 
   - if `method: git`: Tells fabrikate to `git clone <source>`.
-  - if `method: helm`: Tells fabrikate to `helm fetch <path>` from the `source`
-    helm repo.
+  - if `method: helm`: Tells fabrikate to `helm fetch <source>/<path>` from the
+    `source` helm repo. Essentially:
+    `helm repo add foo <my_helm_repository> && helm fetch foo/<path>`
   - if `method: local`: Tells fabrikate to use the host filesystem as a means to
     find the component.
 


### PR DESCRIPTION
- During `fab install`, components which use `method: helm` will now have their dependency repositories temporarily added to the helm client so `helm depency update...` succeeds without having to manually add dependency repositories.
- Some doc clarification.