### PR TITLE
Generate kustomization.yaml, implements #239

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -24,8 +24,7 @@ type kustomization struct {
 
 const kustomizationFileName = "kustomization.yaml"
 
-func writeKustomizationFiles(generationPath string, components []core.Component) (err error) {
-
+func writeKustomizationFile(generationPath string, components []core.Component) (err error) {
 	kustomization := kustomization{}
 
 	kustomization.APIVersion = "kustomize.config.k8s.io/v1beta1"
@@ -127,7 +126,7 @@ func Generate(startPath string, environments []string, validate bool, generateKu
 	}
 
 	if generateKustomization {
-		if err = writeKustomizationFiles(generationPath, components); err != nil {
+		if err = writeKustomizationFile(generationPath, components); err != nil {
 			return nil, err
 		}
 	}
@@ -168,6 +167,6 @@ if it did not conflict with prod or azure.`,
 
 func init() {
 	generateCmd.PersistentFlags().Bool("validate", false, "Validate generated resource manifest YAML")
-	generateCmd.PersistentFlags().BoolP("kustomize", "k", false, fmt.Sprint("Generate a %s file", kustomizationFileName))
+	generateCmd.PersistentFlags().BoolP("kustomize", "k", false, fmt.Sprintf("Generate a %s file", kustomizationFileName))
 	rootCmd.AddCommand(generateCmd)
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -33,8 +33,9 @@ func writeKustomizationFile(generationPath string, components []core.Component) 
 
 	for _, component := range components {
 		componentYAMLFilename := fmt.Sprintf("%s.yaml", component.Name)
-		log.Debug(emoji.Sprintf(":truck: Adding resource %s to %s", componentYAMLFilename, kustomizationFileName))
-		kustomization.Resources = append(kustomization.Resources, componentYAMLFilename)
+		componentYAMLFilepath := path.Join(component.LogicalPath, componentYAMLFilename)
+		log.Debug(emoji.Sprintf(":truck: Adding resource %s to %s", componentYAMLFilepath, kustomizationFileName))
+		kustomization.Resources = append(kustomization.Resources, componentYAMLFilepath)
 	}
 
 	kustomizationBytes, err := yaml.Marshal(kustomization)


### PR DESCRIPTION
This pull request adds a `-k` or `--kustomize` option to `fab generate`. When this option is passed, a **kustomization.yaml** will be generated for each environment with the Kubernetes YAML files added as resources. This allowes executing `kubectl apply -k` on directories with the generated files and therefore solves issues like #20.

This PR implements #239.