### PR TITLE
Log to stdout and stderr as necessary

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/kyokomi/emoji"
 	"github.com/microsoft/fabrikate/core"
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +67,7 @@ $ fab add cloud-native --source https://github.com/microsoft/fabrikate-definitio
 		if cmd.Flags().Changed("method") && method != "git" {
 			// Warn users if they explicitly set --branch that the config is being removed
 			if cmd.Flags().Changed("branch") {
-				log.Warn(emoji.Sprintf(":exclamation: Non 'git' --method and explicit --branch specified. Removing --branch configuration of 'branch: %s'", branch))
+				logger.Warn(emoji.Sprintf(":exclamation: Non 'git' --method and explicit --branch specified. Removing --branch configuration of 'branch: %s'", branch))
 			}
 			branch = ""
 		}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kyokomi/emoji"
 	"github.com/microsoft/fabrikate/core"
 	"github.com/microsoft/fabrikate/generators"
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +28,7 @@ func writeGeneratedManifests(generationPath string, components []core.Component)
 		componentYAMLFilename := fmt.Sprintf("%s.yaml", component.Name)
 		componentYAMLFilePath := path.Join(componentGenerationPath, componentYAMLFilename)
 
-		log.Info(emoji.Sprintf(":floppy_disk: Writing %s", componentYAMLFilePath))
+		logger.Info(emoji.Sprintf(":floppy_disk: Writing %s", componentYAMLFilePath))
 
 		err = ioutil.WriteFile(componentYAMLFilePath, []byte(component.Manifest), 0644)
 		if err != nil {
@@ -40,10 +40,10 @@ func writeGeneratedManifests(generationPath string, components []core.Component)
 }
 
 func validateGeneratedManifests(generationPath string) (err error) {
-	log.Info(emoji.Sprintf(":microscope: Validating generated manifests in path %s", generationPath))
+	logger.Info(emoji.Sprintf(":microscope: Validating generated manifests in path %s", generationPath))
 	if output, err := exec.Command("kubectl", "apply", "--validate=true", "--dry-run", "--recursive", "-f", generationPath).Output(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			log.Errorf("Validating generated manifests failed with: %s: output: %s", ee.Stderr, output)
+			logger.Error(fmt.Sprintf("Validating generated manifests failed with: %s: output: %s", ee.Stderr, output))
 			return err
 		}
 	}
@@ -93,7 +93,7 @@ func Generate(startPath string, environments []string, validate bool) (component
 	}
 
 	if err == nil {
-		log.Info(emoji.Sprintf(":raised_hands: Finished generate"))
+		logger.Info(emoji.Sprintf(":raised_hands: Finished generate"))
 	}
 
 	return components, err

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyokomi/emoji"
 	"github.com/microsoft/fabrikate/core"
 	"github.com/microsoft/fabrikate/generators"
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -21,17 +21,17 @@ func Install(path string) (err error) {
 		if err != nil {
 			return err
 		}
-		log.Info(emoji.Sprintf(":mag: Using %s: %s", tool, path))
+		logger.Info(emoji.Sprintf(":mag: Using %s: %s", tool, path))
 	}
 
-	log.Info(emoji.Sprintf(":point_right: Initializing Helm"))
+	logger.Info(emoji.Sprintf(":point_right: Initializing Helm"))
 	if output, err := exec.Command("helm", "init", "--client-only").CombinedOutput(); err != nil {
-		log.Error(emoji.Sprintf(":no_entry_sign: %s: %s", err, output))
+		logger.Error(emoji.Sprintf(":no_entry_sign: %s: %s", err, output))
 		return err
 	}
 
 	results := core.WalkComponentTree(path, []string{}, func(path string, component *core.Component) (err error) {
-		log.Info(emoji.Sprintf(":point_right: Starting install for component: %s", component.Name))
+		logger.Info(emoji.Sprintf(":point_right: Starting install for component: %s", component.Name))
 
 		var generator core.Generator
 
@@ -55,7 +55,7 @@ func Install(path string) (err error) {
 			return err
 		}
 
-		log.Info(emoji.Sprintf(":point_left: Finished install for component: %s", component.Name))
+		logger.Info(emoji.Sprintf(":point_left: Finished install for component: %s", component.Name))
 
 		return err
 	})
@@ -66,9 +66,9 @@ func Install(path string) (err error) {
 	}
 
 	for _, component := range components {
-		log.Info(emoji.Sprintf(":white_check_mark: Installed successfully: %s", component.Name))
+		logger.Info(emoji.Sprintf(":white_check_mark: Installed successfully: %s", component.Name))
 	}
-	log.Info(emoji.Sprintf(":raised_hands: Finished install"))
+	logger.Info(emoji.Sprintf(":raised_hands: Finished install"))
 
 	return err
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -20,9 +21,9 @@ var rootCmd = &cobra.Command{
 		verbose := cmd.Flag("verbose").Value.String()
 
 		if verbose == "true" {
-			log.SetLevel(log.DebugLevel)
+			logger.SetLevelDebug()
 		} else {
-			log.SetLevel(log.InfoLevel)
+			logger.SetLevelInfo()
 		}
 
 		return nil
@@ -33,7 +34,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Error(err)
+		logger.Error(err)
 		os.Exit(1)
 	}
 }
@@ -53,7 +54,7 @@ func initConfig() {
 		// Find home directory.
 		home, err := os.UserHomeDir()
 		if err != nil {
-			log.Errorf("Getting home directory failed with: %s\n", err)
+			logger.Error(fmt.Sprintf("Getting home directory failed with: %s\n", err))
 			os.Exit(1)
 		}
 
@@ -66,6 +67,6 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		log.Debugf("Using config file: %s\n", viper.ConfigFileUsed())
+		logger.Debug(fmt.Sprintf("Using config file: %s\n", viper.ConfigFileUsed()))
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ var versionCmd = &cobra.Command{
 
 // PrintVersion prints the current version of Fabrikate being used.
 func PrintVersion() {
-	log.Info("fab version 0.15.3")
+	logger.Info("fab version 0.15.3")
 }
 
 func init() {

--- a/core/componentConfig.go
+++ b/core/componentConfig.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/kyokomi/emoji"
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/timfpark/conjungo"
 	yaml "github.com/timfpark/yaml"
 )
@@ -116,7 +116,7 @@ func (cc *ComponentConfig) SetComponentConfig(path []string, value string) {
 			configLevel = configLevel[pathPart].(map[string]interface{})
 		} else {
 			if createdNewConfig {
-				log.Info(emoji.Sprintf(":seedling: Created new value for %s", strings.Join(path, ".")))
+				logger.Info(emoji.Sprintf(":seedling: Created new value for %s", strings.Join(path, ".")))
 			}
 			configLevel[pathPart] = value
 		}
@@ -135,7 +135,7 @@ func (cc *ComponentConfig) GetSubcomponentConfig(subcomponentPath []string) (sub
 		}
 
 		if _, ok := subcomponentConfig.Subcomponents[subcomponentName]; !ok {
-			log.Info(emoji.Sprintf(":seedling: Creating new subcomponent configuration for %s", subcomponentName))
+			logger.Info(emoji.Sprintf(":seedling: Creating new subcomponent configuration for %s", subcomponentName))
 			subcomponentConfig.Subcomponents[subcomponentName] = NewComponentConfig(".")
 		}
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -119,15 +119,21 @@ $ golangci-lint run
 ```
 
 ## Debugging Fabrikate
+
 To debug Fabrikate on [Visual Studio Code](https://code.visualstudio.com/):
+
 1. Open `main.go`
 2. On the top menu select Debug > Start Debugging
-3. It will prompt you to create a `launch.json` file for the go language, proceed to create it.
-4. Update the configuration to debug specific `fabrikate` commands. Follow the instructions below.
+3. It will prompt you to create a `launch.json` file for the go language,
+   proceed to create it.
+4. Update the configuration to debug specific `fabrikate` commands. Follow the
+   instructions below.
 
 ### Debug Configuration
+
 Initially the debug configuration will look like this:
-```
+
+```json
  "configurations": [
         {
             "name": "Launch",
@@ -141,20 +147,27 @@ Initially the debug configuration will look like this:
     ]
 ```
 
-You can specify what `fabrikate` commands you want to debug in the arguments. Below are some examples.
+You can specify what `fabrikate` commands you want to debug in the arguments.
+Below are some examples.
 
 To debug the `install` command:
+
 ```
 "args": ["install", "/home/edaena/Source/repos/sample-component"]
 ```
 
 To debug the `generate` command:
+
 ```
  "args": ["generate", "common"]
 ```
 
 ### Run the Debugger
-For information about how to add breakpoints to the code and more detailed instructions on debugging refer to [Visual Studio Code Debugging](https://code.visualstudio.com/docs/editor/debugging).
+
+For information about how to add breakpoints to the code and more detailed
+instructions on debugging refer to
+[Visual Studio Code Debugging](https://code.visualstudio.com/docs/editor/debugging).
+
 1. Go to the `main.go` file
 2. On the top menu select Debug > Start Debugging
 

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -14,8 +14,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/kyokomi/emoji"
 	"github.com/microsoft/fabrikate/core"
+	"github.com/microsoft/fabrikate/logger"
 	"github.com/otiai10/copy"
-	log "github.com/sirupsen/logrus"
 	"github.com/timfpark/yaml"
 )
 
@@ -95,7 +95,7 @@ func cleanK8sManifest(manifests string) (cleanedManifests string, err error) {
 		// Log a warning if unable to unmarshal; skip the entry
 		if err := yaml.Unmarshal([]byte(manifest), &parsedManifest); err != nil {
 			warning := emoji.Sprintf(":question: Unable to unmarshal manifest into type '%s', this is most likely a warning message outputted from `helm template`.\nRemoving manifest entry: '%s'\nUnmarshal error encountered: '%s'", reflect.TypeOf(parsedManifest), manifest, err)
-			log.Warn(warning)
+			logger.Warn(warning)
 			continue
 		}
 
@@ -146,11 +146,11 @@ func (hg *HelmGenerator) getChartPath(c *core.Component) (string, error) {
 
 // Generate returns the helm templated manifests specified by this component.
 func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, err error) {
-	log.Info(emoji.Sprintf(":truck: Generating component '%s' with helm with repo %s", component.Name, component.Source))
+	logger.Info(emoji.Sprintf(":truck: Generating component '%s' with helm with repo %s", component.Name, component.Source))
 
 	configYaml, err := yaml.Marshal(&component.Config.Config)
 	if err != nil {
-		log.Errorf("Marshalling config yaml for helm generated component '%s' failed with: %s\n", component.Name, err.Error())
+		logger.Error(fmt.Sprintf("Marshalling config yaml for helm generated component '%s' failed with: %s\n", component.Name, err.Error()))
 		return "", err
 	}
 
@@ -161,7 +161,7 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 	}
 	overriddenValuesFileName := fmt.Sprintf("%s.yaml", randomString.String())
 	absOverriddenPath := path.Join(os.TempDir(), overriddenValuesFileName)
-	log.Debug(emoji.Sprintf(":pencil: Writing config %s to %s\n", configYaml, absOverriddenPath))
+	logger.Debug(emoji.Sprintf(":pencil: Writing config %s to %s\n", configYaml, absOverriddenPath))
 	if err = ioutil.WriteFile(absOverriddenPath, configYaml, 0777); err != nil {
 		return "", err
 	}
@@ -177,14 +177,14 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 	if err != nil {
 		return "", err
 	}
-	log.Info(emoji.Sprintf(":memo: Running `helm template` on template '%s'", chartPath))
+	logger.Info(emoji.Sprintf(":memo: Running `helm template` on template '%s'", chartPath))
 	output, err := exec.Command("helm", "template", chartPath, "--values", absOverriddenPath, "--name", component.Name, "--namespace", namespace).CombinedOutput()
 	if err != nil {
-		log.Errorf("helm template failed with:\n%s: %s", err, output)
+		logger.Error(fmt.Sprintf("helm template failed with:\n%s: %s", err, output))
 		return "", err
 	}
 	// Remove any empty/non-map entries in manifests
-	log.Info(emoji.Sprintf(":scissors: Removing empty entries from generated manifests from chart '%s'", chartPath))
+	logger.Info(emoji.Sprintf(":scissors: Removing empty entries from generated manifests from chart '%s'", chartPath))
 	stringManifests, err := cleanK8sManifest(string(output))
 	if err != nil {
 		return "", err
@@ -195,18 +195,18 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 	// opt into injecting these namespaces manually.  We should reassess if this is necessary after Helm 3 is released and client side
 	// templating really becomes a first class function in Helm.
 	if component.Config.InjectNamespace && component.Config.Namespace != "" {
-		log.Info(emoji.Sprintf(":syringe: Injecting namespace '%s' into manifests for component '%s'", component.Config.Namespace, component.Name))
+		logger.Info(emoji.Sprintf(":syringe: Injecting namespace '%s' into manifests for component '%s'", component.Config.Namespace, component.Name))
 		namespacedManifests := ""
 		for resp := range addNamespaceToManifests(stringManifests, component.Config.Namespace) {
 			// If error; return the error immediately
 			if resp.err != nil {
-				log.Error(emoji.Sprintf(":exclamation: Encountered error while injecting namespace '%s' into manifests for component '%s':\n%s", component.Config.Namespace, component.Name, resp.err))
+				logger.Error(emoji.Sprintf(":exclamation: Encountered error while injecting namespace '%s' into manifests for component '%s':\n%s", component.Config.Namespace, component.Name, resp.err))
 				return stringManifests, resp.err
 			}
 
 			// If warning; just log the warning
 			if resp.warn != nil {
-				log.Warn(emoji.Sprintf(":question: Encountered warning while injecting namespace '%s' into manifests for component '%s':\n%s", component.Config.Namespace, component.Name, *resp.warn))
+				logger.Warn(emoji.Sprintf(":question: Encountered warning while injecting namespace '%s' into manifests for component '%s':\n%s", component.Config.Namespace, component.Name, *resp.warn))
 			}
 
 			// Add the manifest if one was returned
@@ -229,13 +229,13 @@ func (hg *HelmGenerator) Install(c *core.Component) (err error) {
 		helmRepoPath := hg.makeHelmRepoPath(c)
 		switch c.Method {
 		case "helm":
-			log.Info(emoji.Sprintf(":helicopter: Component '%s' requesting helm chart '%s' from helm repository '%s'", c.Name, c.Path, c.Source))
+			logger.Info(emoji.Sprintf(":helicopter: Component '%s' requesting helm chart '%s' from helm repository '%s'", c.Name, c.Path, c.Source))
 			if err = hd.downloadChart(c.Source, c.Path, c.Version, helmRepoPath); err != nil {
 				return err
 			}
 		case "git":
 			// Clone whole repo into helm repo path
-			log.Info(emoji.Sprintf(":helicopter: Component '%s' requesting helm chart in path '%s' from git repository '%s'", c.Name, c.Source, c.PhysicalPath))
+			logger.Info(emoji.Sprintf(":helicopter: Component '%s' requesting helm chart in path '%s' from git repository '%s'", c.Name, c.Source, c.PhysicalPath))
 			if err = core.CloneRepo(c.Source, c.Version, helmRepoPath, c.Branch); err != nil {
 				return err
 			}
@@ -278,11 +278,11 @@ func (hd *helmDownloader) downloadChart(repo, chart, version, into string) (err 
 		return err
 	}
 	randomName := randomUUID.String()
-	log.Infof("Adding temporary helm repo %s => %s", repo, randomName)
+	logger.Info(emoji.Sprintf(":pencil: Adding temporary helm repo %s => %s", repo, randomName))
 	hd.mu.Lock()
 	if output, err := exec.Command("helm", "repo", "add", randomName, repo).CombinedOutput(); err != nil {
 		hd.mu.Unlock()
-		log.Error(emoji.Sprintf(":no_entry_sign: Failed adding helm repository '%s'\n%s: %s", repo, err, output))
+		logger.Error(emoji.Sprintf(":no_entry_sign: Failed adding helm repository '%s'\n%s: %s", repo, err, output))
 		return err
 	}
 	hd.mu.Unlock()
@@ -294,7 +294,7 @@ func (hd *helmDownloader) downloadChart(repo, chart, version, into string) (err 
 	if version != "" {
 		downloadVersion = version
 	}
-	log.Info(emoji.Sprintf(":helicopter: Fetching helm chart '%s' version '%s' into '%s'", chart, downloadVersion, randomDir))
+	logger.Info(emoji.Sprintf(":helicopter: Fetching helm chart '%s' version '%s' into '%s'", chart, downloadVersion, randomDir))
 	helmFetchCommandArgs := []string{"fetch", "--untar", "--untardir", randomDir}
 	// Append version if provided
 	if version != "" {
@@ -302,16 +302,16 @@ func (hd *helmDownloader) downloadChart(repo, chart, version, into string) (err 
 	}
 	helmFetchCommandArgs = append(helmFetchCommandArgs, chartName)
 	if output, err := exec.Command("helm", helmFetchCommandArgs...).CombinedOutput(); err != nil {
-		log.Error(emoji.Sprintf(":no_entry_sign: Failed fetching helm chart '%s' from repo '%s'\n%s: %s", chart, repo, err, output))
+		logger.Error(emoji.Sprintf(":no_entry_sign: Failed fetching helm chart '%s' from repo '%s'\n%s: %s", chart, repo, err, output))
 		return err
 	}
 
 	// Remove repository once completed
-	log.Info(emoji.Sprintf(":bomb: Removing temporary helm repo %s", randomName))
+	logger.Info(emoji.Sprintf(":bomb: Removing temporary helm repo %s", randomName))
 	hd.mu.Lock()
 	if output, err := exec.Command("helm", "repo", "remove", randomName).CombinedOutput(); err != nil {
 		hd.mu.Unlock()
-		log.Error(emoji.Sprintf(":no_entry_sign: Failed to `helm repo remove %s`\n%s: %s", randomName, err, output))
+		logger.Error(emoji.Sprintf(":no_entry_sign: Failed to `helm repo remove %s`\n%s: %s", randomName, err, output))
 	}
 	hd.mu.Unlock()
 
@@ -353,7 +353,7 @@ func updateHelmChartDep(chartPath string) (err error) {
 	requirementsYamlPath := path.Join(absChartPath, "requirements.yaml")
 	addedDepRepoList := []string{}
 	if _, err := os.Stat(requirementsYamlPath); err == nil {
-		log.Infof("requirements.yaml found at '%s', ensuring repositories exist on helm client", requirementsYamlPath)
+		logger.Info(fmt.Sprintf("requirements.yaml found at '%s', ensuring repositories exist on helm client", requirementsYamlPath))
 		bytes, err := ioutil.ReadFile(requirementsYamlPath)
 		if err != nil {
 			return err
@@ -365,7 +365,7 @@ func updateHelmChartDep(chartPath string) (err error) {
 
 		// Add each dependency repo with a temp name
 		for _, dep := range requirementsYaml.Dependencies {
-			log.Info(emoji.Sprintf(":pencil: Adding helm dependency repository '%s'", dep.Repository))
+			logger.Info(emoji.Sprintf(":pencil: Adding helm dependency repository '%s'", dep.Repository))
 			randomUUID, err := uuid.NewRandom()
 			if err != nil {
 				return err
@@ -374,7 +374,7 @@ func updateHelmChartDep(chartPath string) (err error) {
 			hd.mu.Lock()
 			if output, err := exec.Command("helm", "repo", "add", randomRepoName, dep.Repository).CombinedOutput(); err != nil {
 				hd.mu.Unlock()
-				log.Error(emoji.Sprintf(":no_entry_sign: Failed to add helm dependency repository '%s' for chart '%s':\n%s", dep.Repository, chartPath, output))
+				logger.Error(emoji.Sprintf(":no_entry_sign: Failed to add helm dependency repository '%s' for chart '%s':\n%s", dep.Repository, chartPath, output))
 				return err
 			}
 			hd.mu.Unlock()
@@ -383,19 +383,19 @@ func updateHelmChartDep(chartPath string) (err error) {
 	}
 
 	// Update dependencies
-	log.Info(emoji.Sprintf(":helicopter: Updating helm chart's dependencies for chart in '%s'", absChartPath))
+	logger.Info(emoji.Sprintf(":helicopter: Updating helm chart's dependencies for chart in '%s'", absChartPath))
 	if output, err := exec.Command("helm", "dependency", "update", chartPath).CombinedOutput(); err != nil {
-		log.Warn(emoji.Sprintf(":no_entry_sign: Updating chart dependencies failed for chart in '%s'; run `helm dependency update %s` for more error details.\n%s: %s", absChartPath, absChartPath, err, output))
+		logger.Warn(emoji.Sprintf(":no_entry_sign: Updating chart dependencies failed for chart in '%s'; run `helm dependency update %s` for more error details.\n%s: %s", absChartPath, absChartPath, err, output))
 		return err
 	}
 
 	// Cleanup temp dependency repositories
 	for _, repo := range addedDepRepoList {
-		log.Info(emoji.Sprintf(":bomb: Removing dependency repository '%s'", repo))
+		logger.Info(emoji.Sprintf(":bomb: Removing dependency repository '%s'", repo))
 		hd.mu.Lock()
 		if output, err := exec.Command("helm", "repo", "remove", repo).CombinedOutput(); err != nil {
 			hd.mu.Unlock()
-			log.Error(output)
+			logger.Error(output)
 			return err
 		}
 		hd.mu.Unlock()

--- a/generators/static.go
+++ b/generators/static.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/kyokomi/emoji"
 	"github.com/microsoft/fabrikate/core"
-	log "github.com/sirupsen/logrus"
+	"github.com/microsoft/fabrikate/logger"
 )
 
 // StaticGenerator uses a static directory of resource manifests to create a rolled up multi-part manifest.
@@ -15,12 +15,12 @@ type StaticGenerator struct{}
 
 // Generate iterates a static directory of resource manifests and creates a multi-part manifest.
 func (sg *StaticGenerator) Generate(component *core.Component) (manifest string, err error) {
-	log.Info(emoji.Sprintf(":truck: Generating component '%s' statically from path %s", component.Name, component.Path))
+	logger.Info(emoji.Sprintf(":truck: Generating component '%s' statically from path %s", component.Name, component.Path))
 
 	staticPath := path.Join(component.PhysicalPath, component.Path)
 	staticFiles, err := ioutil.ReadDir(staticPath)
 	if err != nil {
-		log.Errorf("error reading from directory %s", staticPath);
+		logger.Error(fmt.Sprintf("error reading from directory %s", staticPath))
 		return "", err
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,9 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -97,6 +99,7 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -174,6 +177,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,91 @@
+package logger
+
+import (
+	"os"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// lock is a global mutex lock to gain control of logrus.<SetLevel|SetOutput>
+var lock = sync.RWMutex{}
+
+// SetLevelDebug sets the standard logger level to Debug
+func SetLevelDebug() {
+	lock.Lock()
+	logrus.SetLevel(logrus.DebugLevel)
+	lock.Unlock()
+}
+
+// SetLevelInfo sets the standard logger level to Info
+func SetLevelInfo() {
+	lock.Lock()
+	logrus.SetLevel(logrus.InfoLevel)
+	lock.Unlock()
+}
+
+// Trace logs a message at level Trace to stdout.
+func Trace(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stdout)
+	logrus.Trace(args...)
+	lock.Unlock()
+}
+
+// Debug logs a message at level Debug to stdout.
+func Debug(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stdout)
+	logrus.Debug(args...)
+	lock.Unlock()
+}
+
+// Info logs a message at level Info to stdout.
+func Info(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stdout)
+	logrus.Info(args...)
+	lock.Unlock()
+}
+
+// Warn logs a message at level Warn to stdout.
+func Warn(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stdout)
+	logrus.Warn(args...)
+	lock.Unlock()
+}
+
+// Error logs a message at level Error to stderr.
+func Error(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stderr)
+	logrus.Error(args...)
+	lock.Unlock()
+}
+
+// Fatal logs a message at level Fatal to stderr then the process will exit with status set to 1.
+func Fatal(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stderr)
+	logrus.Fatal(args...)
+	lock.Unlock()
+}
+
+// Panic logs a message at level Panic to stderr; calls panic() after logging.
+func Panic(args ...interface{}) {
+	lock.Lock()
+	logrus.SetOutput(os.Stderr)
+	logrus.Panic(args...)
+	lock.Unlock()
+}
+
+func init() {
+	// Setup logger defaults
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = "02-01-2006 15:04:05"
+	formatter.FullTimestamp = true
+	logrus.SetFormatter(formatter)
+	logrus.SetOutput(os.Stdout) // Set output to stdout; set to stderr by default
+	logrus.SetLevel(logrus.InfoLevel)
+}

--- a/main.go
+++ b/main.go
@@ -4,19 +4,12 @@ import (
 	"reflect"
 
 	"github.com/microsoft/fabrikate/cmd"
-	log "github.com/sirupsen/logrus"
 	"github.com/timfpark/yaml"
 )
 
 func main() {
 	// modify the DefaultMapType of yaml to map[string]interface{} instead of map[interface]interface{}
 	*yaml.DefaultMapType = reflect.TypeOf(map[string]interface{}{})
-
-	formatter := new(log.TextFormatter)
-	formatter.TimestampFormat = "02-01-2006 15:04:05"
-	formatter.FullTimestamp = true
-
-	log.SetFormatter(formatter)
 
 	cmd.Execute()
 }


### PR DESCRIPTION
- Added and abstraction service `logger` on top of logrus which switches the `SetOutput` between `os.Stdout` and `os.Stderr` as necessary.
- Removed all references of logrus from the project and now reference the wrapper service.
- Doc formatting

fixes #251 