### PR TITLE
Fixed `permission denied` regression

### DIFF
--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/google/go-github/v28/github"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetFabrikateComponents(t *testing.T) {
@@ -17,8 +17,8 @@ func TestGetFabrikateComponents(t *testing.T) {
 		"samples/kafka-strimzi-portworx/config/common.yaml",
 	}
 
-	for _, path := range paths{
-		var p string = path
+	for _, path := range paths {
+		var p = path
 		githubCodeResults = append(githubCodeResults, github.CodeResult{Path: &p})
 	}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -23,6 +23,9 @@ func TestInstallJSON(t *testing.T) {
 	// Change cwd to component directory
 	assert.Nil(t, os.Chdir(componentDir))
 	assert.Nil(t, Install("./"))
+
+	// Installing again should not cause errors
+	assert.Nil(t, Install("./"))
 }
 
 func TestInstallYAML(t *testing.T) {
@@ -37,6 +40,9 @@ func TestInstallYAML(t *testing.T) {
 	// Change cwd to component directory
 	assert.Nil(t, os.Chdir(componentDir))
 	assert.Nil(t, Install("./"))
+
+	// Installing again should not cause errors
+	assert.Nil(t, Install("./"))
 }
 
 func TestInstallWithHooks(t *testing.T) {
@@ -50,7 +56,6 @@ func TestInstallWithHooks(t *testing.T) {
 
 	// Change cwd to component directory
 	assert.Nil(t, os.Chdir(componentDir))
-
 	assert.Nil(t, Install("./"))
 }
 
@@ -89,6 +94,9 @@ func TestInstallHelmMethod(t *testing.T) {
 
 	// Change cwd to component directory
 	assert.Nil(t, os.Chdir(componentDir))
+	assert.Nil(t, Install("./"))
+
+	// Installing again should not cause errors
 	assert.Nil(t, Install("./"))
 
 	// Grafana chart should be version 3.7.0

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -236,7 +236,7 @@ func (hg *HelmGenerator) Install(c *core.Component) (err error) {
 		case "git":
 			// Clone whole repo into helm repo path
 			logger.Info(emoji.Sprintf(":helicopter: Component '%s' requesting helm chart in path '%s' from git repository '%s'", c.Name, c.Source, c.PhysicalPath))
-			if err = core.CloneRepo(c.Source, c.Version, helmRepoPath, c.Branch); err != nil {
+			if err = core.Git.CloneRepo(c.Source, c.Version, helmRepoPath, c.Branch); err != nil {
 				return err
 			}
 			// Update chart dependencies in chart path -- this is manually done here but automatically done in downloadChart in the case of `method: helm`
@@ -314,6 +314,11 @@ func (hd *helmDownloader) downloadChart(repo, chart, version, into string) (err 
 		logger.Error(emoji.Sprintf(":no_entry_sign: Failed to `helm repo remove %s`\n%s: %s", randomName, err, output))
 	}
 	hd.mu.Unlock()
+
+	// Remove the into directory if it already exists
+	if err = os.RemoveAll(into); err != nil {
+		return err
+	}
 
 	// copy chart to target `into` dir
 	chartDirectoryInRandomDir := path.Join(randomDir, chart)


### PR DESCRIPTION
- Fixed an error which would occur if a user attempted to `install` a component which already previously been installed. This was caused do to being unable to overwrite existing files in the installed components `.git` directory. The previously installed component is now deleted prior to copying from the clone cache.
-  General cleanup

fixes #228 