### PR TITLE
fix(#261): Helm dependency update broken /w fresh ~/.helm

### DIFF
--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/microsoft/fabrikate/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/timfpark/yaml"
@@ -111,4 +112,40 @@ func TestInstallHelmMethod(t *testing.T) {
 	assert.Nil(t, yaml.Unmarshal(grafanaChartBytes, &grafanaChart))
 	assert.EqualValues(t, "grafana", grafanaChart.Name)
 	assert.EqualValues(t, "3.7.0", grafanaChart.Version)
+}
+
+// Test to cover https://github.com/microsoft/fabrikate/issues/261
+// Tests the calling of Install when the helm client isn't initialized and
+// attempts to get updates from `http://127.0.0.1:8879/charts` which is fails
+// in most cases as people do not typically run helm servers locally.
+func TestInstallWithoutHelmInitialized(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	assert.Nil(t, err)
+	helmDir := path.Join(homeDir, ".helm")
+
+	if _, err := os.Stat(helmDir); !os.IsNotExist(err) {
+		// Move helm dir to a temporary location to simulate uninitialized helm client
+		randomTmpName, err := uuid.NewRandom()
+		assert.Nil(t, err)
+		tmpDir := path.Join(homeDir, randomTmpName.String())
+		assert.Nil(t, os.Rename(helmDir, tmpDir))
+
+		// Ensure it is moved back to normal
+		defer func() {
+			assert.Nil(t, os.RemoveAll(helmDir))
+			assert.Nil(t, os.Rename(tmpDir, helmDir))
+		}()
+	}
+
+	componentDir := "../testdata/install-helm-fix-261-dep-update-bug"
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+	defer func() {
+		assert.Nil(t, os.Chdir(cwd))
+		assert.Nil(t, util.UninstallComponents(componentDir))
+	}()
+
+	// Change cwd to component directory and install
+	assert.Nil(t, os.Chdir(componentDir))
+	assert.Nil(t, Install("./"))
 }

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -387,11 +387,16 @@ func updateHelmChartDep(chartPath string) (err error) {
 		}
 	}
 
-	// Update dependencies
+	// Update dependencies -- Attempt twice; may fail the first time if running on
+	// a newly initialized ~/.helm directory because `helm serve` is typically
+	// not running and helm will attempt to fetch/cache all helm repositories
+	// during first run
 	logger.Info(emoji.Sprintf(":helicopter: Updating helm chart's dependencies for chart in '%s'", absChartPath))
-	if output, err := exec.Command("helm", "dependency", "update", chartPath).CombinedOutput(); err != nil {
-		logger.Warn(emoji.Sprintf(":no_entry_sign: Updating chart dependencies failed for chart in '%s'; run `helm dependency update %s` for more error details.\n%s: %s", absChartPath, absChartPath, err, output))
-		return err
+	if _, err := exec.Command("helm", "dependency", "update", chartPath).CombinedOutput(); err != nil {
+		if attempt2, err := exec.Command("helm", "dependency", "update", chartPath).CombinedOutput(); err != nil {
+			logger.Warn(emoji.Sprintf(":no_entry_sign: Updating chart dependencies failed for chart in '%s'; run `helm dependency update %s` for more error details.\n%s: %s", absChartPath, absChartPath, err, attempt2))
+			return err
+		}
 	}
 
 	// Cleanup temp dependency repositories

--- a/testdata/install-helm-fix-261-dep-update-bug/cloud-native/component.yaml
+++ b/testdata/install-helm-fix-261-dep-update-bug/cloud-native/component.yaml
@@ -1,0 +1,6 @@
+name: cloud-native
+subcomponents:
+  - name: cloud-native-impl
+    source: "https://github.com/timfpark/fabrikate-definitions"
+    method: "git"
+    path: "definitions/fabrikate-cloud-native"

--- a/testdata/install-helm-fix-261-dep-update-bug/component.yaml
+++ b/testdata/install-helm-fix-261-dep-update-bug/component.yaml
@@ -1,0 +1,10 @@
+# https://github.com/timfpark/fabrikate-dep-update-bug/blob/master/component.yaml
+name: repo-bug-repro
+subcomponents:
+  - name: cloud-native
+    source: "./cloud-native"
+  - name: kafka
+    type: "helm"
+    source: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+    method: "helm"
+    path: "kafka"


### PR DESCRIPTION
`updateHelmChartDep` now attempts to run `helm dependency update <chart-path>` twice before reporting an error. This is to fix the use case of a user having non-existent `~/.helm` directory or having never saturated the helm cache. In that case, the first call to `helm dependency update...` will fail as it will attempt to saturate the cache for all repositories (which includes `http://127.0.0.1:8879/charts` by default and the user is most likely not running `helm serve`) but following attempts will succeed as the cache will be saturated. 

fixes #261 