### PR TITLE
Added the --version option to the `Add` command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -43,7 +43,7 @@ func Add(subcomponent core.Component) (err error) {
 }
 
 var addCmd = &cobra.Command{
-	Use:   "add <component-name> --source <component-source> [--type component] [--method git] [--path .]",
+	Use:   "add <component-name> --source <component-source> [--type <component|helm|static>] [--method <git|helm|local|http>] [--path <filepath>] [--version <SHA|tag|helm_chart_version>]",
 	Short: "Adds a subcomponent to the current component (or the component specified by the passed path).",
 	Long: `Adds a subcomponent to the current component (or the component specified by the passed path).
 
@@ -54,7 +54,7 @@ path: the path to the component that this subcomponent should be added to.
 
 example:
 
-$ fab add cloud-native --source https://github.com/microsoft/fabrikate-definitions --path definitions/fabrikate-cloud-native
+$ fab add cloud-native --source https://github.com/microsoft/fabrikate-definitions --path definitions/fabrikate-cloud-native --branch master --version v1.0.0
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
@@ -77,6 +77,7 @@ $ fab add cloud-native --source https://github.com/microsoft/fabrikate-definitio
 			Source:        cmd.Flag("source").Value.String(),
 			Method:        method,
 			Branch:        branch,
+			Version:       cmd.Flag("version").Value.String(),
 			Path:          cmd.Flag("path").Value.String(),
 			ComponentType: cmd.Flag("type").Value.String(),
 		}
@@ -88,9 +89,10 @@ $ fab add cloud-native --source https://github.com/microsoft/fabrikate-definitio
 func init() {
 	addCmd.PersistentFlags().String("source", "", "Source for this component")
 	addCmd.PersistentFlags().String("method", "git", "Method to use to fetch this component")
-	addCmd.PersistentFlags().String("branch", "master", "Branch of git repo to use; noop when method != 'git'")
-	addCmd.PersistentFlags().String("path", "./", "Path of git repo to use")
+	addCmd.PersistentFlags().String("branch", "master", "Branch of git repo to use; noop when method is 'git'")
+	addCmd.PersistentFlags().String("path", "", "Path of git repo to use")
 	addCmd.PersistentFlags().String("type", "component", "Type of this component")
+	addCmd.PersistentFlags().String("version", "", "Commit SHA or Tag to checkout of the git repo when method is 'git' or the version of the helm chart to fetch when method is 'helm'")
 
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -27,6 +27,7 @@ func TestAdd(t *testing.T) {
 		Source:        "https://github.com/timfpark/fabrikate-cloud-native",
 		Method:        "git",
 		ComponentType: "component",
+		Version:       "8ad79e73e0665e347e1553ad7ca32b6e590e007a",
 	}
 
 	err = Add(componentComponent)
@@ -42,6 +43,13 @@ func TestAdd(t *testing.T) {
 
 	err = Add(helmComponent)
 	assert.Nil(t, err)
+
+	// Ensure the correct values are being added to the added subcomponents
+	currentComponent := core.Component{}
+	currentComponent, err = currentComponent.LoadComponent()
+	assert.Nil(t, err)
+	assert.EqualValues(t, componentComponent, currentComponent.Subcomponents[0])
+	assert.EqualValues(t, helmComponent, currentComponent.Subcomponents[1])
 
 	////////////////////////////////////////////////////////////////////////////////
 	// Test adding a subcomponent

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,7 +30,7 @@ var versionCmd = &cobra.Command{
 
 // PrintVersion prints the current version of Fabrikate being used.
 func PrintVersion() {
-	logger.Info("fab version 0.16.2")
+	logger.Info("fab version 0.17.0")
 }
 
 func init() {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,19 +8,23 @@ passed path).
 ### Usage
 
 ```sh
-$ fab add <component-name> --source <component-source> [--type component] [--method git] [--path .]
+$ fab add <component-name> --source <component-source> [--type <component|helm|static>] [--method <git|helm|local|http>] [--path <filepath>] [--version <SHA|tag|helm_chart_version>]
 ```
 
 Where:
 
-- `source` specifies where the component lives (either a local path or remote
-  http(s) endpoint)
+- `source` specifies where the component lives (either a local path, remote http
+  endpoint, or a helm repository url)
 - `type` specifies the type of component (`component` (default), `helm`, or
   `static`)
-- `method` specifies the method that should be used to fetch the component
-  (`git` (default))
-- `path` specifies the path to the component that this subcomponent should be
-  added to.
+- `method` specifies the method used to source the `source` (`git` (default))
+- `path` specifies:
+  - if `method == 'git'`: the relative path in the git repository where the
+    component exists
+  - if `method == 'helm'`: the name of the helm chart in the helm repository
+- `version` specifies:
+  - if `method == 'git'`: a specific SHA or tag to `git checkout`
+  - if `method == 'helm'`: the version of the helm chart to `helm fetch`
 
 ### Example
 

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,7 @@ golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc h1:gkKoSkUmnU6bpS/VhkuO27bzQeSA51uaEfbOW5dNb68=
 golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/testdata/add/component.yaml
+++ b/testdata/add/component.yaml
@@ -5,6 +5,7 @@ subcomponents:
   type: component
   source: https://github.com/timfpark/fabrikate-cloud-native
   method: git
+  version: 8ad79e73e0665e347e1553ad7ca32b6e590e007a
 - name: elasticsearch
   type: helm
   source: https://github.com/helm/charts


### PR DESCRIPTION
Users can now specify the component `version` via the `--version` flag
when calling `Add`