### PR TITLE
Add capability to disable subcomponent per environment

### DIFF
--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -69,3 +69,17 @@ func TestGenerateWithHooks(t *testing.T) {
 
 	assert.Nil(t, err)
 }
+
+func TestGenerateDisabledSubcomponent(t *testing.T) {
+	components, err := Generate("../testdata/generate-disabled", []string{"disabled"}, false)
+
+	expectedLengths := map[string]int{
+		"my-stack": 0,
+		"pod-info": 4795,
+	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(components))
+
+	checkComponentLengthsAgainstExpected(t, components, expectedLengths)
+}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -74,8 +74,8 @@ func TestGenerateDisabledSubcomponent(t *testing.T) {
 	components, err := Generate("../testdata/generate-disabled", []string{"disabled"}, false)
 
 	expectedLengths := map[string]int{
-		"my-stack": 0,
-		"pod-info": 4795,
+		"disabled-stack": 0,
+		"pod-info":       4769,
 	}
 
 	assert.Nil(t, err)

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -75,11 +75,10 @@ func TestGenerateDisabledSubcomponent(t *testing.T) {
 
 	expectedLengths := map[string]int{
 		"disabled-stack": 0,
-		"pod-info":       4769,
 	}
 
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(components))
+	assert.Equal(t, 1, len(components))
 
 	checkComponentLengthsAgainstExpected(t, components, expectedLengths)
 }

--- a/core/component.go
+++ b/core/component.go
@@ -338,6 +338,12 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 
 	// Enqueue the given component
 	enqueue := func(c Component) {
+		// Do not add to the queue if component or subcomponent is Disabled.
+		if c.Config.Disabled {
+			logger.Info(emoji.Sprintf(":prohibited: Component '%s' is disabled", c.Name))
+			return
+		}
+
 		// Increment working counter; MUST happen BEFORE sending to queue or race condition can occur
 		walking.Add(1)
 		logger.Debug(fmt.Sprintf("Adding subcomponent '%s' to queue with physical path '%s' and logical path '%s'\n", c.Name, c.PhysicalPath, c.LogicalPath))

--- a/core/component.go
+++ b/core/component.go
@@ -338,12 +338,6 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 
 	// Enqueue the given component
 	enqueue := func(c Component) {
-		// Do not add to the queue if component or subcomponent is Disabled.
-		if c.Config.Disabled {
-			logger.Info(emoji.Sprintf(":prohibited: Component '%s' is disabled", c.Name))
-			return
-		}
-
 		// Increment working counter; MUST happen BEFORE sending to queue or race condition can occur
 		walking.Add(1)
 		logger.Debug(fmt.Sprintf("Adding subcomponent '%s' to queue with physical path '%s' and logical path '%s'\n", c.Name, c.PhysicalPath, c.LogicalPath))
@@ -400,6 +394,12 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 
 					if err = subcomponent.applyDefaultsAndMigrations(); err != nil {
 						results <- WalkResult{Error: err}
+					}
+
+					// Do not add to the queue if component or subcomponent is Disabled.
+					if subcomponent.Config.Disabled {
+						logger.Info(emoji.Sprintf(":prohibited: Subcomponent '%s' is disabled", subcomponent.Name))
+						continue
 					}
 
 					// Depending if the subcomponent is inlined or not; prepare the component to either load

--- a/core/componentConfig.go
+++ b/core/componentConfig.go
@@ -20,7 +20,7 @@ type ComponentConfig struct {
 	Serialization   string                     `yaml:"-" json:"-"`
 	Namespace       string                     `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	InjectNamespace bool                       `yaml:"injectNamespace,omitempty" json:"injectNamespace,omitempty"`
-	Disabled 		bool                       `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	Disabled        bool                       `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 	Config          map[string]interface{}     `yaml:"config,omitempty" json:"config,omitempty"`
 	Subcomponents   map[string]ComponentConfig `yaml:"subcomponents,omitempty" json:"subcomponents,omitempty"`
 }

--- a/core/componentConfig.go
+++ b/core/componentConfig.go
@@ -20,6 +20,7 @@ type ComponentConfig struct {
 	Serialization   string                     `yaml:"-" json:"-"`
 	Namespace       string                     `yaml:"namespace,omitempty" json:"namespace,omitempty"`
 	InjectNamespace bool                       `yaml:"injectNamespace,omitempty" json:"injectNamespace,omitempty"`
+	Disabled 		bool                       `yaml:"disabled,omitempty" json:"disabled,omitempty"`
 	Config          map[string]interface{}     `yaml:"config,omitempty" json:"config,omitempty"`
 	Subcomponents   map[string]ComponentConfig `yaml:"subcomponents,omitempty" json:"subcomponents,omitempty"`
 }

--- a/core/componentConfig_test.go
+++ b/core/componentConfig_test.go
@@ -142,3 +142,35 @@ func TestWriteJSON(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 132, len(configContents))
 }
+
+func TestDisabledDefault(t *testing.T) {
+	config := NewComponentConfig("../testdata/disabled")
+
+	err := config.Load("default")
+	assert.Nil(t, err)
+
+	cloudNativeSubcomponent := config.Subcomponents["cloud-native"]
+	elasticsearchSubcomponent := config.Subcomponents["elasticsearch"]
+
+	cloudNativeDisabled := cloudNativeSubcomponent.Disabled
+	assert.Equal(t, false, cloudNativeDisabled)
+
+	elasticsearchDisabled := elasticsearchSubcomponent.Disabled
+	assert.Equal(t, false, elasticsearchDisabled)
+}
+
+func TestDisabledTrue(t *testing.T) {
+	config := NewComponentConfig("../testdata/disabled")
+
+	err := config.Load("disabled")
+	assert.Nil(t, err)
+
+	cloudNativeSubcomponent := config.Subcomponents["cloud-native"]
+	elasticsearchSubcomponent := config.Subcomponents["elasticsearch"]
+
+	cloudNativeDisabled := cloudNativeSubcomponent.Disabled
+	assert.Equal(t, true, cloudNativeDisabled)
+
+	elasticsearchDisabled := elasticsearchSubcomponent.Disabled
+	assert.Equal(t, true, elasticsearchDisabled)
+}

--- a/core/component_test.go
+++ b/core/component_test.go
@@ -140,3 +140,36 @@ func TestWriteComponent(t *testing.T) {
 	err = component.Write()
 	assert.Nil(t, err)
 }
+
+func TestLoadDisabledComponentDefaultValue(t *testing.T) {
+	component := Component{
+		PhysicalPath: "../testdata/disabled",
+		LogicalPath:  "",
+	}
+
+	component, err := component.LoadComponent()
+	assert.Nil(t, err)
+
+	err = component.LoadConfig([]string{"default"})
+	assert.Nil(t, err)
+
+	assert.Equal(t, false, component.Config.Subcomponents["cloud-native"].Disabled)
+	assert.Equal(t, false, component.Config.Subcomponents["elasticsearch"].Disabled)
+
+}
+
+func TestLoadDisabledComponent(t *testing.T) {
+	component := Component{
+		PhysicalPath: "../testdata/disabled",
+		LogicalPath:  "",
+	}
+
+	component, err := component.LoadComponent()
+	assert.Nil(t, err)
+
+	err = component.LoadConfig([]string{"disabled"})
+	assert.Nil(t, err)
+
+	assert.Equal(t, true, component.Config.Subcomponents["cloud-native"].Disabled)
+	assert.Equal(t, true, component.Config.Subcomponents["elasticsearch"].Disabled)
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -86,3 +86,14 @@ subcomponents:
   istio-crd:
     namespace: istio-system
 ```
+
+### Disable subcomponents per environment
+
+It is possible to disable subcomponent per environment with a simple `disabled: true` in the
+environment config file
+
+```yaml
+subcomponents:
+  redis:
+    disabled: true
+```

--- a/testdata/disabled/component.yaml
+++ b/testdata/disabled/component.yaml
@@ -1,0 +1,13 @@
+name: disabled
+type: component
+subcomponents:
+- name: cloud-native
+  type: component
+  source: https://github.com/timfpark/fabrikate-cloud-native
+  method: git
+  version: 8ad79e73e0665e347e1553ad7ca32b6e590e007a
+- name: elasticsearch
+  type: helm
+  source: https://github.com/helm/charts
+  method: git
+  path: stable/elasticsearch

--- a/testdata/disabled/config/default.yaml
+++ b/testdata/disabled/config/default.yaml
@@ -1,0 +1,6 @@
+subcomponents:
+  elasticsearch:
+    config:
+      fod: rad
+      foo: rad
+      zoo: zaa

--- a/testdata/disabled/config/disabled.yaml
+++ b/testdata/disabled/config/disabled.yaml
@@ -1,0 +1,7 @@
+subcomponents:
+  cloud-native:
+    disabled: true
+  elasticsearch:
+    disabled: true
+    config:
+      fod: bar

--- a/testdata/generate-disabled/component.yaml
+++ b/testdata/generate-disabled/component.yaml
@@ -1,0 +1,18 @@
+name: disabled-stack
+type: component
+subcomponents:
+ - name: pod-info
+   type: helm
+   method: git
+   source: https://github.com/stefanprodan/podinfo
+   path: charts/podinfo
+ - name: mysql
+   type: helm
+   method: git
+   source: https://github.com/helm/charts
+   path: stable/mysql
+ - name: bookinfo # Istio BookInfo application - wrapped in Fabrikate component
+   source: https://github.com/microsoft/fabrikate-definitions.git
+   path: definitions/fabrikate-bookinfo
+   method: git
+

--- a/testdata/generate-disabled/config/disabled.yaml
+++ b/testdata/generate-disabled/config/disabled.yaml
@@ -1,0 +1,10 @@
+subcomponents:
+  pod-info:
+    config:
+      env: local
+  mysql:
+    disabled: true
+    config:
+      env: local
+  bookinfo:
+    disabled: true

--- a/testdata/generate-disabled/config/disabled.yaml
+++ b/testdata/generate-disabled/config/disabled.yaml
@@ -1,5 +1,6 @@
 subcomponents:
   pod-info:
+    disabled: true
     config:
       env: local
   mysql:


### PR DESCRIPTION
# Add capability to disable subcomponent per environment

I'm really interested in this feature so opening this PR to contribute.
From the issue #277 I have preferred the property `disabled`  over excluded.

## what I changed
I'm proposing the addition of a disabled attribute to the Subcomponents Config. 
The default value is `false` so all subcomponents will be enabled by default.

Basically we will be able to disabled components per environment:

```yaml
..config/myenv.yaml..

subcomponents:
  my-subcomponent:
    disabled: true
```

closes #277 