### PR TITLE
feat: #292 - add top level environments that allow conditional genera…

### DIFF
--- a/cmd/find.go
+++ b/cmd/find.go
@@ -4,32 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
-	"github.com/spf13/cobra"
 	"github.com/google/go-github/v28/github"
+	"github.com/spf13/cobra"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
 // FindComponent finds fabrikate components in the fabrikate-definitions repository that are related to the given keyword.
-func FindComponent(keyword string)(error){
+func FindComponent(keyword string) error {
 
 	client := github.NewClient(nil)
 	ctx := context.Background()
 	query := keyword + "+repo:microsoft/fabrikate-definitions"
 
 	results, _, err := client.Search.Code(ctx, query, nil)
-	
-	if (err != nil || results.CodeResults == nil){
+
+	if err != nil || results.CodeResults == nil {
 		return err
 	}
 
 	components := GetFabrikateComponents(results.CodeResults)
 
 	fmt.Println(fmt.Sprintf("Search results for '%s':", keyword))
-	if (len(components) == 0){
+	if len(components) == 0 {
 		log.Info(fmt.Sprintf("No components were found for '%s'", keyword))
-	} else{
+	} else {
 		for _, component := range components {
 			fmt.Println(component)
 		}
@@ -39,19 +39,19 @@ func FindComponent(keyword string)(error){
 }
 
 // GetFabrikateComponents returns a unique list of fabrikate components from a github search result
-func GetFabrikateComponents(codeResults []github.CodeResult) ([]string){
-	
-	if (codeResults == nil){
+func GetFabrikateComponents(codeResults []github.CodeResult) []string {
+
+	if codeResults == nil {
 		return []string{}
 	}
 
 	components := []string{}
-	uniqueComponents :=  map[string]bool{}
+	uniqueComponents := map[string]bool{}
 
-	for _, result := range codeResults{
+	for _, result := range codeResults {
 
 		path := *result.Path
-		if(!strings.HasPrefix(path, "definitions")){
+		if !strings.HasPrefix(path, "definitions") {
 			continue
 		}
 
@@ -64,7 +64,7 @@ func GetFabrikateComponents(codeResults []github.CodeResult) ([]string){
 		}
 	}
 
-	return components;
+	return components
 }
 
 var findCmd = &cobra.Command{
@@ -75,8 +75,8 @@ Eg.
 $ fab find prometheus
 Finds fabrikate components that are related to 'prometheus'.
 `,
-	RunE: func(cmd *cobra.Command, args []string) (err error){
-		
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+
 		if len(args) != 1 {
 			return errors.New("'find' takes one argument")
 		}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -69,3 +69,33 @@ func TestGenerateWithHooks(t *testing.T) {
 
 	assert.Nil(t, err)
 }
+
+func TestGenerateConditionalSubcomponents(t *testing.T) {
+	components, err := Generate("../testdata/generate-conditional/subcomponent", []string{"staging"}, false)
+
+	expectedLengths := map[string]int{
+		"test":    0,
+		"grafana": 84,
+		"random":  86,
+	}
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, 3, len(components))
+
+	checkComponentLengthsAgainstExpected(t, components, expectedLengths)
+}
+
+func TestGenerateConditionalRoot(t *testing.T) {
+	components, err := Generate("../testdata/generate-conditional/root", []string{"staging"}, false)
+
+	expectedLengths := map[string]int{
+		"test": 0,
+	}
+
+	assert.Nil(t, err)
+
+	assert.Equal(t, 0, len(components))
+
+	checkComponentLengthsAgainstExpected(t, components, expectedLengths)
+}

--- a/core/component.go
+++ b/core/component.go
@@ -31,6 +31,7 @@ type Component struct {
 	Path          string              `yaml:"path,omitempty" json:"path,omitempty"`
 	Version       string              `yaml:"version,omitempty" json:"version,omitempty"`
 	Branch        string              `yaml:"branch,omitempty" json:"branch,omitempty"`
+	TargetConfigs []string            `yaml:"configs,omitempty" json:"configs,omitempty"`
 
 	Repositories  map[string]string `yaml:"repositories,omitempty" json:"repositories,omitempty"`
 	Subcomponents []Component       `yaml:"subcomponents,omitempty" json:"subcomponents,omitempty"`
@@ -323,6 +324,7 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 	// Note: this is only needed for non-inlined components
 	prepareComponent := func(c Component) Component {
 		logger.Debug(fmt.Sprintf("Preparing component '%s'", c.Name))
+
 		// 1. Parse the component at that path into a Component
 		c, err := c.LoadComponent()
 		if err != nil {
@@ -350,6 +352,23 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 		walking.Done()
 	}
 
+	// Check if the component should be traversed according to the configured environments
+
+	traversable := func(c Component, environments []string) bool {
+		containsEnv := func(s1 []string, s2 []string) bool {
+			for _, el1 := range s1 {
+				for _, el2 := range s2 {
+					if el1 == el2 {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		return len(c.TargetConfigs) == 0 || containsEnv(environments, c.TargetConfigs)
+	}
+
 	// Main worker thread to enqueue root node, wait, and close the channel once all nodes visited
 	go func() {
 		// Manually enqueue the first root component
@@ -360,13 +379,16 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 			Config:       NewComponentConfig(startingPath),
 		})
 
-		// Init rootComponent
-		rootComponent, err := rootInit(startingPath, environments, rootComponent)
+		if traversable(rootComponent, environments) {
+			// Init rootComponent
+			rootComponent, err := rootInit(startingPath, environments, rootComponent)
 
-		if err != nil {
-			results <- WalkResult{Error: err}
-		} else {
-			enqueue(rootComponent)
+			if err != nil {
+				results <- WalkResult{Error: err}
+			} else {
+				enqueue(rootComponent)
+			}
+
 		}
 
 		// Close results channel once all nodes visited
@@ -389,31 +411,35 @@ func WalkComponentTree(startingPath string, environments []string, iterator comp
 
 				// Range over subcomponents; preparing and enqueuing
 				for _, subcomponent := range c.Subcomponents {
-					// Prep component config
-					subcomponent.Config = c.Config.Subcomponents[subcomponent.Name]
+					if traversable(subcomponent, environments) {
+						// Prep component config
+						subcomponent.Config = c.Config.Subcomponents[subcomponent.Name]
 
-					if err = subcomponent.applyDefaultsAndMigrations(); err != nil {
-						results <- WalkResult{Error: err}
-					}
-
-					// Depending if the subcomponent is inlined or not; prepare the component to either load
-					// config/path info from filesystem (non-inlined) or inherit from parent (inlined)
-					if subcomponent.ComponentType == "component" || subcomponent.ComponentType == "" {
-						// This subcomponent is not inlined, so set the paths to their relative positions and prepare the configs
-						subcomponent.PhysicalPath = path.Join(subcomponent.RelativePathTo(), subcomponent.Path)
-						if !filepath.IsAbs(subcomponent.RelativePathTo()) {
-							subcomponent.PhysicalPath = path.Join(c.PhysicalPath, subcomponent.PhysicalPath)
+						if err = subcomponent.applyDefaultsAndMigrations(); err != nil {
+							results <- WalkResult{Error: err}
 						}
-						subcomponent.LogicalPath = path.Join(c.LogicalPath, subcomponent.Name)
-						subcomponent = prepareComponent(subcomponent)
-					} else {
-						// This subcomponent is inlined, so it inherits paths from parent and no need to prepareComponent().
-						subcomponent.PhysicalPath = c.PhysicalPath
-						subcomponent.LogicalPath = c.LogicalPath
-					}
 
-					logger.Debug(fmt.Sprintf("Adding subcomponent '%s' to queue with physical path '%s' and logical path '%s'\n", subcomponent.Name, subcomponent.PhysicalPath, subcomponent.LogicalPath))
-					enqueue(subcomponent)
+						// Depending if the subcomponent is inlined or not; prepare the component to either load
+						// config/path info from filesystem (non-inlined) or inherit from parent (inlined)
+						if subcomponent.ComponentType == "component" || subcomponent.ComponentType == "" {
+							// This subcomponent is not inlined, so set the paths to their relative positions and prepare the configs
+							subcomponent.PhysicalPath = path.Join(subcomponent.RelativePathTo(), subcomponent.Path)
+							if !filepath.IsAbs(subcomponent.RelativePathTo()) {
+								subcomponent.PhysicalPath = path.Join(c.PhysicalPath, subcomponent.PhysicalPath)
+							}
+							subcomponent.LogicalPath = path.Join(c.LogicalPath, subcomponent.Name)
+							subcomponent = prepareComponent(subcomponent)
+						} else {
+							// This subcomponent is inlined, so it inherits paths from parent and no need to prepareComponent().
+							subcomponent.PhysicalPath = c.PhysicalPath
+							subcomponent.LogicalPath = c.LogicalPath
+						}
+
+						logger.Debug(fmt.Sprintf("Adding subcomponent '%s' to queue with physical path '%s' and logical path '%s'\n", subcomponent.Name, subcomponent.PhysicalPath, subcomponent.LogicalPath))
+						enqueue(subcomponent)
+					} else {
+						logger.Debug(fmt.Sprintf("Not adding subcomponent '%s' to queue because it's not traversable (environments: %s, subcomponent environments: %s)\n", subcomponent.Name, environments, subcomponent.TargetConfigs))
+					}
 				}
 			}(queuedComponent)
 		}

--- a/generators/helm.go
+++ b/generators/helm.go
@@ -167,7 +167,7 @@ func (hg *HelmGenerator) Generate(component *core.Component) (manifest string, e
 	overriddenValuesFileName := fmt.Sprintf("%s.yaml", randomString.String())
 	absOverriddenPath := path.Join(os.TempDir(), overriddenValuesFileName)
 	defer os.Remove(absOverriddenPath)
-	
+
 	logger.Debug(emoji.Sprintf(":pencil: Writing config %s to %s\n", configYaml, absOverriddenPath))
 	if err = ioutil.WriteFile(absOverriddenPath, configYaml, 0777); err != nil {
 		return "", err

--- a/testdata/generate-conditional/root/component.yaml
+++ b/testdata/generate-conditional/root/component.yaml
@@ -1,0 +1,8 @@
+name: test
+type: component
+configs:
+  - production
+subcomponents:
+  - name: grafana
+    type: static
+    path: manifests/production

--- a/testdata/generate-conditional/root/manifests/production/grafana-namespace.yaml
+++ b/testdata/generate-conditional/root/manifests/production/grafana-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  environment: production

--- a/testdata/generate-conditional/root/manifests/staging/grafana-namespace.yaml
+++ b/testdata/generate-conditional/root/manifests/staging/grafana-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  environment: staging

--- a/testdata/generate-conditional/subcomponent/component.yaml
+++ b/testdata/generate-conditional/subcomponent/component.yaml
@@ -1,0 +1,19 @@
+name: test
+type: component
+subcomponents:
+  - name: grafana
+    type: static
+    path: ./manifests/staging
+    configs: 
+    - staging
+  - name: grafana
+    type: static
+    path: ./manifests/production
+    configs: 
+    - production
+  - name: random
+    type: static
+    path: ./manifests/test
+    configs: 
+    - test
+    - staging

--- a/testdata/generate-conditional/subcomponent/manifests/production/grafana-namespace.yaml
+++ b/testdata/generate-conditional/subcomponent/manifests/production/grafana-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  environment: production

--- a/testdata/generate-conditional/subcomponent/manifests/staging/grafana-namespace.yaml
+++ b/testdata/generate-conditional/subcomponent/manifests/staging/grafana-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+  environment: staging

--- a/testdata/generate-conditional/subcomponent/manifests/test/another-namespace.yaml
+++ b/testdata/generate-conditional/subcomponent/manifests/test/another-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace
+  environment: staging


### PR DESCRIPTION
Here's an attempt to allow top level configs to allow conditional components based on `generate` configs. 
I called them configs because of the nomenclature used on the commands documentation page, though, they might be consider as environments.

* Empty slice means retro compatibility
* Specifying an array of configs means that traversal will check against the environments passed