### PR TITLE
added daily builds at midnight

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,11 @@
+schedules:
+  - cron: "0 0 * * *"
+    displayName: "Daily midnight build"
+    branches:
+      include:
+        - master
+    always: true
+
 pool:
   vmImage: "Ubuntu-16.04"
 


### PR DESCRIPTION
* Daily builds ensure that code on master will not go stale, even if no new changes were introduced
* Will ensure that contributors can know the status of tests on master, always
* [Here is a link](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml) to the AZDO docs for schedules to read more